### PR TITLE
[core][enhancement] Disable WeakRef usage in WyW modulate evaluation

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -210,6 +210,11 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
             themeArgs: {
               theme,
             },
+            features: {
+              useWeakRefInEval: false,
+              // If users know what they are doing, let them override to true
+              ...rest.features,
+            },
             overrideContext(context: Record<string, unknown>, filename: string) {
               if (overrideContext) {
                 return overrideContext(context, filename);

--- a/packages/pigment-css-vite-plugin/src/vite-plugin.ts
+++ b/packages/pigment-css-vite-plugin/src/vite-plugin.ts
@@ -186,6 +186,11 @@ export default function wywVitePlugin({
               preprocessor,
               pluginOptions: {
                 ...rest,
+                features: {
+                  useWeakRefInEval: false,
+                  // If users know what they are doing, let them override to true
+                  ...rest.features,
+                },
                 babelOptions: {
                   ...rest.babelOptions,
                   plugins: [


### PR DESCRIPTION
phase to avoid the "Invariant: Module 00041 has been disposed" issues. This results in more reliability but at the cost of more memory consumption which should be fine for now.

Related to https://github.com/mui/material-ui/pull/41909, https://github.com/Anber/wyw-in-js/pull/71
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
