### PR TITLE
[nextjs][bug] Transform !important css to an intermediate representation

### DIFF
--- a/packages/pigment-css-nextjs-plugin/src/virtual-css-loader.js
+++ b/packages/pigment-css-nextjs-plugin/src/virtual-css-loader.js
@@ -2,5 +2,5 @@ export const loader = function virtualFileLoader() {
   const callback = this.async();
   const resourceQuery = this.resourceQuery.slice(1);
   const { source } = JSON.parse(decodeURIComponent(resourceQuery));
-  return callback(null, source);
+  return callback(null, source.replaceAll('__IMP__', '!important'));
 };

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -287,7 +287,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
           const data = `${meta.placeholderCssFile}?${encodeURIComponent(
             JSON.stringify({
               filename: id.split('/').pop(),
-              source: cssText,
+              source: cssText.replaceAll('!important', '__IMP__'),
             }),
           )}`;
           return {

--- a/packages/pigment-css-unplugin/tsconfig.json
+++ b/packages/pigment-css-unplugin/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "target": "ES2022",
+    "lib": ["ES2021", "DOM"],
     "paths": {
       "@babel/core": ["./node_modules/@babel/core"],
       "@pigment-css/react": ["./packages/pigment-css-react/src"],


### PR DESCRIPTION
Webpack/Nextjs was interpreting `!important` as a loader pipe resulting in an error.

Fixes #34 
Fixes issue in https://github.com/mui/material-ui/pull/42001

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
