### PR TITLE
Fix styled inheritance

### DIFF
--- a/packages/pigment-css-react/src/styled.js
+++ b/packages/pigment-css-react/src/styled.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-/* eslint-disable react/prop-types */
 import * as React from 'react';
 import clsx from 'clsx';
 import isPropValid from '@emotion/is-prop-valid';

--- a/packages/pigment-css-react/src/styled.js
+++ b/packages/pigment-css-react/src/styled.js
@@ -86,11 +86,11 @@ export default function styled(tag, componentMeta = {}) {
     const { displayName, classes = [], vars: cssVars = {}, variants = [] } = options;
 
     const StyledComponent = React.forwardRef(function StyledComponent(inProps, ref) {
-      const { as, className, sx, style, ownerState, ...props } = inProps;
-      const Component = (shouldUseAs && as) || tag;
+      const { className, sx, style, ownerState, ...props } = inProps;
+      const Component = (shouldUseAs && inProps.as) || tag;
       const varStyles = Object.entries(cssVars).reduce(
         (acc, [cssVariable, [variableFunction, isUnitLess]]) => {
-          const value = variableFunction({ ownerState, ...props });
+          const value = variableFunction(inProps);
           if (typeof value === 'undefined') {
             return acc;
           }
@@ -130,7 +130,7 @@ export default function styled(tag, componentMeta = {}) {
           continue;
         }
 
-        if (finalShouldForwardProp(key)) {
+        if (finalShouldForwardProp(key) || (!shouldUseAs && key === 'as')) {
           newProps[key] = props[key];
         }
       }

--- a/packages/pigment-css-react/src/styled.js
+++ b/packages/pigment-css-react/src/styled.js
@@ -87,11 +87,11 @@ export default function styled(tag, componentMeta = {}) {
     const { displayName, classes = [], vars: cssVars = {}, variants = [] } = options;
 
     const StyledComponent = React.forwardRef(function StyledComponent(inProps, ref) {
-      const { as, className, sx, style, ...props } = inProps;
+      const { as, className, sx, style, ownerState, ...props } = inProps;
       const Component = (shouldUseAs && as) || tag;
       const varStyles = Object.entries(cssVars).reduce(
         (acc, [cssVariable, [variableFunction, isUnitLess]]) => {
-          const value = variableFunction(props);
+          const value = variableFunction({ ownerState, ...props });
           if (typeof value === 'undefined') {
             return acc;
           }
@@ -140,7 +140,7 @@ export default function styled(tag, componentMeta = {}) {
         <Component
           {...newProps}
           // pass down `ownerState` to nested styled components
-          {...(Component.__styled_by_pigment_css && { ownerState: props.ownerState })}
+          {...(Component.__styled_by_pigment_css && { ownerState })}
           ref={ref}
           className={finalClassName}
           style={{
@@ -156,7 +156,6 @@ export default function styled(tag, componentMeta = {}) {
       componentName = `${name}${slot ? `-${slot}` : ''}`;
     }
     StyledComponent.displayName = `Styled(${componentName})`;
-    // eslint-disable-next-line no-underscore-dangle
     StyledComponent.__styled_by_pigment_css = true;
 
     return StyledComponent;

--- a/packages/pigment-css-react/src/styled.js
+++ b/packages/pigment-css-react/src/styled.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable react/prop-types */
 import * as React from 'react';
 import clsx from 'clsx';
 import isPropValid from '@emotion/is-prop-valid';
@@ -58,7 +60,12 @@ export default function styled(tag, componentMeta = {}) {
       finalShouldForwardProp = slotShouldForwardProp;
     }
   }
-  const shouldUseAs = !finalShouldForwardProp('as');
+  let shouldUseAs = !finalShouldForwardProp('as');
+  if (typeof tag !== 'string' && tag.__styled_by_pigment_css) {
+    // If the tag is a Pigment styled component,
+    // render the styled component and pass the `as` prop down
+    shouldUseAs = false;
+  }
   /**
    * This is the runtime `styled` function that finally renders the component
    * after transpilation through WyW-in-JS. It makes sure to add the base classes,
@@ -80,7 +87,7 @@ export default function styled(tag, componentMeta = {}) {
     const { displayName, classes = [], vars: cssVars = {}, variants = [] } = options;
 
     const StyledComponent = React.forwardRef(function StyledComponent(inProps, ref) {
-      const { as, className, sx, style, ownerState, ...props } = inProps;
+      const { as, className, sx, style, ...props } = inProps;
       const Component = (shouldUseAs && as) || tag;
       const varStyles = Object.entries(cssVars).reduce(
         (acc, [cssVariable, [variableFunction, isUnitLess]]) => {
@@ -133,8 +140,7 @@ export default function styled(tag, componentMeta = {}) {
         <Component
           {...newProps}
           // pass down `ownerState` to nested styled components
-          // eslint-disable-next-line no-underscore-dangle
-          {...(Component.__styled_by_pigment_css && { ownerState })}
+          {...(Component.__styled_by_pigment_css && { ownerState: props.ownerState })}
           ref={ref}
           className={finalClassName}
           style={{

--- a/packages/pigment-css-react/tests/styled/runtime-styled.test.js
+++ b/packages/pigment-css-react/tests/styled/runtime-styled.test.js
@@ -263,37 +263,36 @@ describe('props filtering', () => {
         classes: ['InputBase-input'],
       });
 
-      const InputBase = ({
+      function InputBase({
         inputComponent = 'input',
         slots = {},
         slotProps = {},
         inputProps: inputPropsProp = {},
-      }) => {
-        const Root = slots.root || InputBaseRoot;
+      }) {
+        const RootSlot = slots.root || InputBaseRoot;
         const rootProps = slotProps.root || {};
 
-        let InputComponent = inputComponent;
-        let inputProps = inputPropsProp;
+        const InputComponent = inputComponent;
 
-        const Input = slots.input || InputBaseInput;
-        inputProps = { ...inputProps, ...slotProps.input };
+        const InputSlot = slots.input || InputBaseInput;
+        const inputProps = { ...inputPropsProp, ...slotProps.input };
         return (
-          <Root
+          <RootSlot
             {...rootProps}
             {...(typeof Root !== 'string' && {
               ownerState: rootProps.ownerState,
             })}
           >
-            <Input
+            <InputSlot
               {...inputProps}
               {...(typeof Input !== 'string' && {
                 as: InputComponent,
                 ownerState: inputProps.ownerState,
               })}
             />
-          </Root>
+          </RootSlot>
         );
-      };
+      }
 
       const InputRoot = styled(InputBaseRoot, { name: 'MuiInput', slot: 'Root' })({
         classes: ['Input-root'],
@@ -301,14 +300,14 @@ describe('props filtering', () => {
       const InputInput = styled(InputBaseInput, { name: 'MuiInput', slot: 'Input' })({
         classes: ['Input-input'],
       });
-      const Input = ({
+      function Input({
         inputComponent = 'input',
         multiline = false,
         slotProps,
         slots = {},
         type,
         ...other
-      }) => {
+      }) {
         const RootSlot = slots.root ?? InputRoot;
         const InputSlot = slots.input ?? InputInput;
         return (
@@ -321,7 +320,7 @@ describe('props filtering', () => {
             {...other}
           />
         );
-      };
+      }
 
       const defaultInput = <Input />;
       const NativeSelectSelect = styled('select', {
@@ -330,7 +329,7 @@ describe('props filtering', () => {
       })({
         classes: ['NativeSelect-select'],
       });
-      const NativeSelectInput = (props) => {
+      function NativeSelectInput(props) {
         const { className, disabled, error, variant = 'standard', ...other } = props;
 
         const ownerState = {
@@ -348,14 +347,8 @@ describe('props filtering', () => {
             {...other}
           />
         );
-      };
-      const NativeSelect = ({
-        className,
-        children,
-        input = defaultInput,
-        inputProps,
-        ...other
-      }) => {
+      }
+      function NativeSelect({ className, children, input = defaultInput, inputProps, ...other }) {
         return React.cloneElement(input, {
           inputComponent: NativeSelectInput,
           inputProps: {
@@ -367,7 +360,7 @@ describe('props filtering', () => {
           ...other,
           className: `${input.props.className} ${className}`,
         });
-      };
+      }
 
       const { container } = render(
         <NativeSelect>

--- a/packages/pigment-css-react/tests/styled/runtime-styled.test.js
+++ b/packages/pigment-css-react/tests/styled/runtime-styled.test.js
@@ -202,4 +202,54 @@ describe('props filtering', () => {
       expect(container.firstChild).to.have.class('root-123');
     });
   });
+
+  describe('as', () => {
+    it("child's classes still propagate to its parent", () => {
+      const StyledChild = styled('span')({
+        classes: ['child'],
+      });
+
+      const StyledParent = styled(StyledChild)({
+        classes: ['parent'],
+      });
+
+      const { container } = render(<StyledParent as="div" />);
+      expect(container.firstChild).to.have.class('child');
+    });
+
+    it("child's variants still propagate to its parent", () => {
+      const StyledChild = styled('span')({
+        classes: ['child'],
+        variants: [
+          {
+            props: ({ ownerState }) => ownerState.multiline,
+            className: 'multiline',
+          },
+        ],
+      });
+
+      const StyledParent = styled(StyledChild)({
+        classes: ['parent'],
+      });
+
+      const { container } = render(<StyledParent as="div" ownerState={{ multiline: true }} />);
+      expect(container.firstChild).to.have.class('multiline');
+    });
+
+    it("child's vars still propagate to its parent", () => {
+      const StyledChild = styled('span')({
+        classes: ['child'],
+        vars: {
+          foo: [(props) => props.ownerState.width, false],
+        },
+      });
+
+      const StyledParent = styled(StyledChild)({
+        classes: ['parent'],
+      });
+
+      const { container } = render(<StyledParent as="div" ownerState={{ width: 300 }} />);
+      expect(container.firstChild).to.have.style('--foo', '300px');
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

A Pigment styled component (child) is replaced by `as` value provided to the parent:


```js
const Child = styled('span')({ classes: ['child'] });

const Parent = styled(Child)({ classes: ['parent'] });

<Parent as="div" />; // <div class="parent" />
```

This behavior is different from Emotion & Styled-components where styles of child are propagated even `as` is provided to the parent.

## Expected

```js
const Child = styled('span')({ classes: ['child'] });

const Parent = styled(Child)({ classes: ['parent'] });

<Parent as="div" />; // <div class="child parent" />
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
