### PR TITLE
Fix prop forwarding when `as` component is provided to HTML styled component

### DIFF
--- a/packages/pigment-css-react/src/styled.js
+++ b/packages/pigment-css-react/src/styled.js
@@ -123,14 +123,14 @@ export default function styled(tag, componentMeta = {}) {
         getVariantClasses(inProps, variants),
       );
 
-      if (shouldUseAs && !shouldForwardProp) {
-        // Reassign `shouldForwardProp` based on the incoming `as` prop
-        if (isHtmlTag(Component)) {
-          finalShouldForwardProp = isPropValid;
-        } else if (slot === 'Root' || slot === 'root') {
-          finalShouldForwardProp = rootShouldForwardProp;
-        } else {
-          finalShouldForwardProp = slotShouldForwardProp;
+      if (inProps.as && !shouldForwardProp) {
+        // Reassign `shouldForwardProp` if incoming `as` prop is a React component
+        if (!isHtmlTag(Component)) {
+          if (slot === 'Root' || slot === 'root') {
+            finalShouldForwardProp = rootShouldForwardProp;
+          } else {
+            finalShouldForwardProp = slotShouldForwardProp;
+          }
         }
       }
 

--- a/packages/pigment-css-react/src/styled.js
+++ b/packages/pigment-css-react/src/styled.js
@@ -123,6 +123,17 @@ export default function styled(tag, componentMeta = {}) {
         getVariantClasses(inProps, variants),
       );
 
+      if (shouldUseAs && !shouldForwardProp) {
+        // Reassign `shouldForwardProp` based on the incoming `as` prop
+        if (isHtmlTag(Component)) {
+          finalShouldForwardProp = isPropValid;
+        } else if (slot === 'Root' || slot === 'root') {
+          finalShouldForwardProp = rootShouldForwardProp;
+        } else {
+          finalShouldForwardProp = slotShouldForwardProp;
+        }
+      }
+
       const newProps = {};
       // eslint-disable-next-line no-restricted-syntax
       for (const key in props) {

--- a/packages/pigment-css-react/tests/styled/runtime-styled.test.js
+++ b/packages/pigment-css-react/tests/styled/runtime-styled.test.js
@@ -252,6 +252,20 @@ describe('props filtering', () => {
       expect(container.firstChild).to.have.style('--foo', '300px');
     });
 
+    it('use component forward prop if provided `as` is a component', () => {
+      const StyledDiv = styled('div')({
+        classes: ['root'],
+      });
+
+      function Component({ TagComponent = 'span', ...props }) {
+        return <TagComponent {...props} />;
+      }
+
+      const { container } = render(<StyledDiv as={Component} TagComponent="button" disabled />);
+
+      expect(container.firstChild).to.have.tagName('button');
+    });
+
     it('should forward `as` prop', () => {
       // The components below is a simplified version of the `NativeSelect` component from Material UI.
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

Found this issue while migrating Material UI Select component. The issue can be simplified as:

```js
const StyledDiv = styled('div')({
  classes: ['root'],
});

function Component({ TagComponent = 'span', ...props }) {
  return <TagComponent {...props} />;
}

<StyledDiv as={Component} TagComponent="button" disabled />; // <span /> instead of <button />
```

This is because the `shouldForwardProp` is not reassigned based on `as` prop like in [Emotion](https://github.com/emotion-js/emotion/blob/f4640f6a7cbe77f790e07706b287cb29342fd0ea/packages/styled/src/base.js#L142).

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
