### PR TITLE
[docs] Fix roadmap link

### DIFF
--- a/examples/pigment-css-nextjs-ts/src/app/page.tsx
+++ b/examples/pigment-css-nextjs-ts/src/app/page.tsx
@@ -183,7 +183,7 @@ export default function Home() {
         </Link>
         <Link
           outlined
-          href="https://github.com/orgs/mui/projects/27/views/1"
+          href="https://github.com/orgs/mui/projects/27/views/3"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/examples/pigment-css-remix-ts/app/routes/_index.tsx
+++ b/examples/pigment-css-remix-ts/app/routes/_index.tsx
@@ -189,7 +189,7 @@ export default function Index() {
         </Link>
         <Link
           outlined
-          href="https://github.com/orgs/mui/projects/27/views/1"
+          href="https://github.com/orgs/mui/projects/27/views/3"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/examples/pigment-css-vite-ts/src/App.tsx
+++ b/examples/pigment-css-vite-ts/src/App.tsx
@@ -185,7 +185,7 @@ export default function Home() {
         </Link>
         <Link
           outlined
-          href="https://github.com/orgs/mui/projects/27/views/1"
+          href="https://github.com/orgs/mui/projects/27/views/3"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
The board view makes a lot more sense to me.

## Before

https://github.com/orgs/mui/projects/27/views/1
<img width="862" alt="SCR-20240508-qbgu" src="https://github.com/mui/material-ui/assets/3165635/22c14562-a7ce-41f5-b43f-e7b4348136a9">

## After

https://github.com/orgs/mui/projects/27/views/3
<img width="1052" alt="SCR-20240508-qbhp" src="https://github.com/mui/material-ui/assets/3165635/a70351ff-a381-43d0-b6b8-9769001a6cdd">
