### PR TITLE
[fix] Implement variant matching parity

### DIFF
--- a/packages/pigment-css-react/src/styled.js
+++ b/packages/pigment-css-react/src/styled.js
@@ -3,12 +3,11 @@ import * as React from 'react';
 import clsx from 'clsx';
 import isPropValid from '@emotion/is-prop-valid';
 
-function getVariantClasses(componentProps, variants) {
-  const { ownerState = {} } = componentProps;
+function getVariantClasses({ ownerState = {}, ...componentProps }, variants) {
   const variantClasses = variants
     .filter(({ props: variantProps }) =>
       typeof variantProps === 'function'
-        ? variantProps({ ...componentProps, ...componentProps.ownerState })
+        ? variantProps({ ...componentProps, ...ownerState, ownerState })
         : Object.entries(variantProps).every(([propKey, propValue]) => {
             return ownerState[propKey] === propValue || componentProps[propKey] === propValue;
           }),


### PR DESCRIPTION
Follow up on https://github.com/mui/material-ui/pull/42358#pullrequestreview-2081441990

Merge props and `ownerState` the same way it's done in MUI System's `createStyled`

cc: @mnajdova 
