### PR TITLE
[unplugin] Fix the path check for Windows

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -335,6 +335,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
       ...(isNext
         ? {
             transformInclude(id) {
+              console.log('transformInclude', id);
               return (
                 // this file should exist in the package
                 id.endsWith(`${process.env.RUNTIME_PACKAGE_NAME}/styles.css`) ||
@@ -348,6 +349,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
               );
             },
             transform(_code, id) {
+              console.log('transform', id);
               if (id.endsWith('styles.css')) {
                 return theme ? generateTokenCss(theme) : _code;
               }

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -335,29 +335,29 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
       ...(isNext
         ? {
             transformInclude(id) {
-              console.log('transformInclude', id);
+              id = id.replace(/\\/g, '/');
+              if (id.includes('@pigment-css')) {
+                console.log('transformInclude', id);
+              }
               return (
                 // this file should exist in the package
                 id.endsWith(`${process.env.RUNTIME_PACKAGE_NAME}/styles.css`) ||
-                id.endsWith(`${process.env.RUNTIME_PACKAGE_NAME}\\styles.css`) ||
                 id.endsWith('/pigment-css-react/styles.css') ||
-                id.endsWith('/pigment-css-react\\styles.css') ||
                 id.includes(`${process.env.RUNTIME_PACKAGE_NAME}/theme`) ||
-                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}\\theme`) ||
-                id.includes('/pigment-css-react/theme') ||
-                id.includes('\\pigment-css-react\\theme')
+                id.includes('/pigment-css-react/theme')
               );
             },
             transform(_code, id) {
-              console.log('transform', id);
+              id = id.replace(/\\/g, '/');
+              if (id.includes('@pigment-css')) {
+                console.log('transform', id);
+              }
               if (id.endsWith('styles.css')) {
                 return theme ? generateTokenCss(theme) : _code;
               }
               if (
                 id.includes('pigment-css-react/theme') ||
-                id.includes('pigment-css-react\\theme') ||
-                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}/theme`) ||
-                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}\\theme`)
+                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}/theme`)
               ) {
                 return generateThemeSource(theme);
               }

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -338,9 +338,13 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
               return (
                 // this file should exist in the package
                 id.endsWith(`${process.env.RUNTIME_PACKAGE_NAME}/styles.css`) ||
+                id.endsWith(`${process.env.RUNTIME_PACKAGE_NAME}\\styles.css`) ||
                 id.endsWith('/pigment-css-react/styles.css') ||
+                id.endsWith('/pigment-css-react\\styles.css') ||
                 id.includes(`${process.env.RUNTIME_PACKAGE_NAME}/theme`) ||
-                id.includes('/pigment-css-react/theme')
+                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}\\theme`) ||
+                id.includes('/pigment-css-react/theme') ||
+                id.includes('\\pigment-css-react\\theme')
               );
             },
             transform(_code, id) {
@@ -349,7 +353,9 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
               }
               if (
                 id.includes('pigment-css-react/theme') ||
-                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}/theme`)
+                id.includes('pigment-css-react\\theme') ||
+                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}/theme`) ||
+                id.includes(`${process.env.RUNTIME_PACKAGE_NAME}\\theme`)
               ) {
                 return generateThemeSource(theme);
               }

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -336,9 +336,6 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
         ? {
             transformInclude(id) {
               id = id.replace(/\\/g, '/');
-              if (id.includes('@pigment-css')) {
-                console.log('transformInclude', id);
-              }
               return (
                 // this file should exist in the package
                 id.endsWith(`${process.env.RUNTIME_PACKAGE_NAME}/styles.css`) ||
@@ -349,9 +346,6 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
             },
             transform(_code, id) {
               id = id.replace(/\\/g, '/');
-              if (id.includes('@pigment-css')) {
-                console.log('transform', id);
-              }
               if (id.endsWith('styles.css')) {
                 return theme ? generateTokenCss(theme) : _code;
               }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

On Windows, the received `id` is `...\@pigment-css\react\theme` but the unplugin only check for `/`. That's why the `generateThemeSource()` is not called which is result in `{}` for runtime theme and the build is error for components that try to use the theme.

**Before**: https://github.com/mui/material-ui/actions/runs/9475564524/job/26107055930?pr=42476

**After**: https://github.com/mui/material-ui/actions/runs/9476406034/job/26109235879?pr=42476

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
