### PR TITLE
[react] Export `globalCss` from index

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "size:snapshot": "node --max-old-space-size=4096 ./scripts/sizeSnapshot/create",
     "size:why": "pnpm size:snapshot --analyze",
     "test": "node scripts/test.mjs",
-    "tc": "node test/cli.js",
+    "tc": "node scripts/cli.js",
     "test:extended": "pnpm eslint && pnpm typescript && pnpm test:coverage",
     "test:coverage": "pnpm build && cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=text mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}'",
     "test:coverage:ci": "pnpm build && cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=lcov mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}'",
@@ -39,7 +39,7 @@
     "test:regressions:server": "serve test/regressions -p 5001",
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.{js,ts,tsx}' 'docs/**/*.test.{js,ts,tsx}'",
     "test:argos": "node ./scripts/pushArgos.mjs",
-    "typescript": "tsc -b tsconfig.typecheck.json",
+    "typescript": "lerna run --no-bail --parallel typescript",
     "typescript:ci": "lerna run --concurrency 3 --no-bail --no-sort typescript",
     "validate-declarations": "tsx scripts/validateTypescriptDeclarations.mts"
   },

--- a/packages/pigment-css-react/package.json
+++ b/packages/pigment-css-react/package.json
@@ -28,7 +28,7 @@
     "test": "cd ../../ && cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=text mocha 'packages/pigment-css-react/**/*.test.{js,ts,tsx}'",
     "test:update": "cd ../../ && cross-env NODE_ENV=test UPDATE_FIXTURES=true mocha 'packages/pigment-css-react/**/*.test.{js,ts,tsx}'",
     "test:ci": "cd ../../ && cross-env NODE_ENV=test BABEL_ENV=coverage nyc --reporter=lcov --report-dir=./coverage/pigment-css-react mocha 'packages/pigment-css-react/**/*.test.{js,ts,tsx}'",
-    "typecheck": "tsc --noEmit -p ."
+    "typescript": "tsc --noEmit -p ."
   },
   "dependencies": {
     "@babel/core": "^7.24.4",

--- a/packages/pigment-css-react/src/index.spec.ts
+++ b/packages/pigment-css-react/src/index.spec.ts
@@ -1,0 +1,66 @@
+import { css, globalCss, keyframes, styled, sx } from '@pigment-css/react';
+
+declare module '@pigment-css/react/theme' {
+  interface ThemeArgs {
+    theme: {
+      palette: {
+        primary: {
+          main: string;
+        };
+      };
+    };
+  }
+}
+
+css``;
+css({
+  color: 'red',
+});
+
+globalCss`
+  html {
+    font-size: 16px;
+  }
+`;
+globalCss(({ theme }) => ({
+  body: {
+    color: theme.palette.primary.main,
+  },
+}));
+
+keyframes``;
+keyframes(() => ({
+  from: {
+    opacity: 0,
+  },
+  to: {
+    opacity: 1,
+  },
+}));
+
+styled.div``;
+styled.div(({ theme }) => ({
+  color: theme.palette.primary.main,
+}));
+
+sx({ color: 'red' });
+sx(({ theme }) => ({
+  color: theme.palette.primary.main,
+}));
+sx([
+  { color: 'red' },
+  ({ theme }) => ({
+    color: theme.palette.primary.main,
+  }),
+]);
+const foo = true;
+sx([
+  true && { color: 'red' },
+  foo
+    ? ({ theme }) => ({
+        color: theme.palette.primary.main,
+      })
+    : {
+        color: 'blue',
+      },
+]);

--- a/packages/pigment-css-react/src/index.ts
+++ b/packages/pigment-css-react/src/index.ts
@@ -7,3 +7,4 @@ export { default as css } from './css';
 export { default as createUseThemeProps } from './createUseThemeProps';
 export { default as internal_createExtendSxProp } from './createExtendSxProp';
 export { default as useTheme } from './useTheme';
+export { default as globalCss } from './globalCss';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,25 +261,25 @@ importers:
         version: 11.11.0
       '@mui/base':
         specifier: next
-        version: 5.0.0-beta.47(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 5.0.0-beta.49(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/icons-material':
         specifier: next
-        version: 6.0.0-alpha.9(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/lab':
         specifier: next
-        version: 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/material':
         specifier: next
-        version: 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/material-nextjs':
         specifier: next
-        version: 6.0.0-alpha.1(@emotion/cache@11.11.0)(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(next@14.2.3(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/cache@11.11.0)(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(next@14.2.4(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@mui/system':
         specifier: next
-        version: 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/utils':
         specifier: next
-        version: 6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)
       '@pigment-css/react':
         specifier: workspace:^
         version: link:../../packages/pigment-css-react
@@ -288,7 +288,7 @@ importers:
         version: link:../local-ui-lib
       next:
         specifier: latest
-        version: 14.2.3(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.4(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -319,22 +319,22 @@ importers:
     dependencies:
       '@mui/base':
         specifier: next
-        version: 5.0.0-beta.47(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 5.0.0-beta.49(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/icons-material':
         specifier: next
-        version: 6.0.0-alpha.9(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/lab':
         specifier: next
-        version: 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/material':
         specifier: next
-        version: 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/system':
         specifier: next
-        version: 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/utils':
         specifier: next
-        version: 6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)
       '@pigment-css/react':
         specifier: workspace:^
         version: link:../../packages/pigment-css-react
@@ -447,10 +447,10 @@ importers:
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/system':
         specifier: ^6.0.0-alpha.6
-        version: 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/utils':
         specifier: ^6.0.0-alpha.6
-        version: 6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)
+        version: 6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)
       '@wyw-in-js/processor-utils':
         specifier: ^0.5.3
         version: 0.5.3
@@ -1671,8 +1671,8 @@ packages:
   '@floating-ui/dom@1.6.3':
     resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
 
-  '@floating-ui/react-dom@2.0.8':
-    resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
+  '@floating-ui/react-dom@2.1.0':
+    resolution: {integrity: sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -1700,6 +1700,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1707,6 +1708,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@hutson/parse-repository-url@3.0.2':
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
@@ -1878,8 +1880,8 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@mui/base@5.0.0-beta.47':
-    resolution: {integrity: sha512-az3gd5tqiZvhDlR2DDVqmJ16PCvUSNb/SzDodjBY4xMu9FKO1LmB7YkcMmJ4CHsTgQ2/TlDIkb0GXmxhmcbRqw==}
+  '@mui/base@5.0.0-beta.49':
+    resolution: {integrity: sha512-SCkSNDgsVAIEVzK00rdahzuDrMM99GEEPxGFO/dW2i06eq3poSBpwWGU8ujMqp8qsJc8KA99aGP2PowY9kUwgQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^18.2.74
@@ -1892,11 +1894,11 @@ packages:
   '@mui/core-downloads-tracker@6.0.0-dev.240424162023-9968b4889d':
     resolution: {integrity: sha512-doh3M3U7HUGSBIWGe1yvesSbfDguMRjP0N09ogWSBM2hovXAlgULhMgcRTepAZLLwfRxFII0bCohq6B9NqoKuw==}
 
-  '@mui/icons-material@6.0.0-alpha.9':
-    resolution: {integrity: sha512-ihM4kigacOD6A1bTp0kLsvPHcoEnioTG5JZkcHW57i1JKdSA2legk7nFJQIfRmhtFQkzy5+qDtqoRDSnJqX+jQ==}
+  '@mui/icons-material@6.0.0-alpha.11':
+    resolution: {integrity: sha512-4UEQJHgss0D0F4GPGe2m7ZMmIdlYnPYISMn+VoODFflLPPSFsWh+yLcpYalmXPep961rOb2Vjbnx4lE1sb4J8Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      '@mui/material': ^6.0.0-alpha.9
+      '@mui/material': ^6.0.0-alpha.11
       '@types/react': ^18.2.74
       react: ^17.0.0 || ^18.0.0
     peerDependenciesMeta:
@@ -1918,13 +1920,13 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  '@mui/lab@6.0.0-alpha.9':
-    resolution: {integrity: sha512-r8XhOUqtMukdfU9yzjDDBY0vnjikI1N0ocBil1kdq0Fu9U+q/iAVEOPSuP6VhyAS4xBuQ5uk6tu5iPI20xEw3A==}
+  '@mui/lab@6.0.0-alpha.11':
+    resolution: {integrity: sha512-iN0+GtxoFDZ2k+eSSQ0nxpxc3b9J2YA6/NKegj0EoJT80h5omuFZtguqsaAXRbmY3UDCfrmrSDof6ynn0cenTA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
       '@emotion/styled': ^11.3.0
-      '@mui/material': ^6.0.0-alpha.9
+      '@mui/material': ^6.0.0-alpha.11
       '@types/react': ^18.2.74
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
@@ -1936,13 +1938,13 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/material-nextjs@6.0.0-alpha.1':
-    resolution: {integrity: sha512-HDUS+GOv/R9k++bnJvIVfWXIWDvP3xzMM5eQB9lxnKbqeJq66VkoIuNTKaCrcHk5Im8bsEoPRrBWbA94X86isA==}
+  '@mui/material-nextjs@6.0.0-alpha.11':
+    resolution: {integrity: sha512-4bLqUA7Gxq8LYAtxBsxd56tFOTVVlhS9bgA67hmIoQmk/h/ST6jo58mGLitMIDMg1IwRjJuIK1uuHmRzIOBNMw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/cache': ^11.11.0
       '@emotion/server': ^11.11.0
-      '@mui/material': ^6.0.0-alpha.7
+      '@mui/material': ^6.0.0-alpha.11
       '@types/react': ^18.2.74
       next: ^13.0.0 || ^14.0.0
       react: ^17.0.0 || ^18.0.0
@@ -1954,8 +1956,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/material@6.0.0-alpha.9':
-    resolution: {integrity: sha512-o4+qrdGPPVysfWvEQgH5C3VG8Z0rBAVX7BjDyVysXfePnx0eHpa5ZavPLSJ1aAeqnqbrECu7bdfFXPAgAMbO7g==}
+  '@mui/material@6.0.0-alpha.11':
+    resolution: {integrity: sha512-SJuNtt5Rt8japz8LWp0p/fEfI2v0HtpfmMi/lRpseiDaInE7PdrwAObxn2wzbgYg/FejDGCBeMn+xCh92HwZGw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -1998,8 +2000,8 @@ packages:
       '@emotion/styled':
         optional: true
 
-  '@mui/system@6.0.0-alpha.9':
-    resolution: {integrity: sha512-kZ6bjX/nS1GYsZw7F464bHjPen3b+c+Ihf+tEziiGrgMdGVYNiC1MNrXVdorsi7g5Ig02aERcv/n/9FENrcw4A==}
+  '@mui/system@6.0.0-alpha.11':
+    resolution: {integrity: sha512-RceH1GU0M7aKNFIaQ92n5uR0moRbsuPfWh08F2Z9jz0k/y/59Tj/IVsdSYnjncnoGxhS3HfL3qJM8gRIkbdF1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@emotion/react': ^11.5.0
@@ -2022,8 +2024,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@mui/utils@6.0.0-alpha.9':
-    resolution: {integrity: sha512-fie2VEiVzpHCbcUIwgWx5lQT+SYjL3uHDCfutXzr7hTbnqDu9KSVEBPgADitFqZOGCIcBXfs4aE4LIn1FmmKjg==}
+  '@mui/utils@6.0.0-alpha.11':
+    resolution: {integrity: sha512-L4GpoTSWH6lVmMghR4a8j5SYOcXwR1jRSvKD6CEs42SOkdYH9lYdDumR6xOzrR+ROV97oB6sh44pVc2GWNLxhg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/react': ^18.2.74
@@ -2057,8 +2059,8 @@ packages:
   '@next/env@13.5.6':
     resolution: {integrity: sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==}
 
-  '@next/env@14.2.3':
-    resolution: {integrity: sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA==}
+  '@next/env@14.2.4':
+    resolution: {integrity: sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg==}
 
   '@next/eslint-plugin-next@14.1.4':
     resolution: {integrity: sha512-n4zYNLSyCo0Ln5b7qxqQeQ34OZKXwgbdcx6kmkQbywr+0k6M3Vinft0T72R6CDAcDrne2IAgSud4uWCzFgc5HA==}
@@ -2069,8 +2071,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@14.2.3':
-    resolution: {integrity: sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==}
+  '@next/swc-darwin-arm64@14.2.4':
+    resolution: {integrity: sha512-AH3mO4JlFUqsYcwFUHb1wAKlebHU/Hv2u2kb1pAuRanDZ7pD/A/KPD98RHZmwsJpdHQwfEc/06mgpSzwrJYnNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2081,8 +2083,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@14.2.3':
-    resolution: {integrity: sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==}
+  '@next/swc-darwin-x64@14.2.4':
+    resolution: {integrity: sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -2093,8 +2095,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-gnu@14.2.3':
-    resolution: {integrity: sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==}
+  '@next/swc-linux-arm64-gnu@14.2.4':
+    resolution: {integrity: sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2105,8 +2107,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@14.2.3':
-    resolution: {integrity: sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==}
+  '@next/swc-linux-arm64-musl@14.2.4':
+    resolution: {integrity: sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2117,8 +2119,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@14.2.3':
-    resolution: {integrity: sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==}
+  '@next/swc-linux-x64-gnu@14.2.4':
+    resolution: {integrity: sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2129,8 +2131,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@14.2.3':
-    resolution: {integrity: sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==}
+  '@next/swc-linux-x64-musl@14.2.4':
+    resolution: {integrity: sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2141,8 +2143,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@14.2.3':
-    resolution: {integrity: sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==}
+  '@next/swc-win32-arm64-msvc@14.2.4':
+    resolution: {integrity: sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2153,8 +2155,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@next/swc-win32-ia32-msvc@14.2.3':
-    resolution: {integrity: sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==}
+  '@next/swc-win32-ia32-msvc@14.2.4':
+    resolution: {integrity: sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -2165,8 +2167,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@14.2.3':
-    resolution: {integrity: sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==}
+  '@next/swc-win32-x64-msvc@14.2.4':
+    resolution: {integrity: sha512-tkLrjBzqFTP8DVrAAQmZelEahfR9OxWpFR++vAI9FBhCiIxtwHwBHC23SBHCTURBtwB4kc/x44imVOnkKGNVGg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5989,8 +5991,8 @@ packages:
       sass:
         optional: true
 
-  next@14.2.3:
-    resolution: {integrity: sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==}
+  next@14.2.4:
+    resolution: {integrity: sha512-R8/V7vugY+822rsQGQCjoLhMuC9oFj9SOi4Cl4b2wjDrseD0LRZ10W7R6Czo4w9ZznVSshKjuIomsRjvm9EKJQ==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -9256,7 +9258,7 @@ snapshots:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
 
-  '@floating-ui/react-dom@2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react-dom@2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/dom': 1.6.3
       react: 18.2.0
@@ -9524,12 +9526,12 @@ snapshots:
       react-test-renderer: 18.2.0(react@18.2.0)
       semver: 5.7.2
 
-  '@mui/base@5.0.0-beta.47(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@mui/base@5.0.0-beta.49(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-dom': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.75)
-      '@mui/utils': 6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)
+      '@mui/utils': 6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)
       '@popperjs/core': 2.11.8
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -9540,10 +9542,10 @@ snapshots:
 
   '@mui/core-downloads-tracker@6.0.0-dev.240424162023-9968b4889d': {}
 
-  '@mui/icons-material@6.0.0-alpha.9(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)':
+  '@mui/icons-material@6.0.0-alpha.11(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
-      '@mui/material': 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/material': 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.75
@@ -9609,14 +9611,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mui/lab@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@mui/lab@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
-      '@mui/base': 5.0.0-beta.47(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@mui/material': 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@mui/system': 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
+      '@mui/base': 5.0.0-beta.49(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/material': 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/system': 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.75)
-      '@mui/utils': 6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)
+      '@mui/utils': 6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.2.0
@@ -9626,24 +9628,24 @@ snapshots:
       '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@types/react': 18.2.75
 
-  '@mui/material-nextjs@6.0.0-alpha.1(@emotion/cache@11.11.0)(@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(next@14.2.3(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@mui/material-nextjs@6.0.0-alpha.11(@emotion/cache@11.11.0)(@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.75)(next@14.2.4(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
-      '@mui/material': 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      next: 14.2.3(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/material': 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 14.2.4(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
       '@emotion/cache': 11.11.0
       '@types/react': 18.2.75
 
-  '@mui/material@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@mui/material@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
-      '@mui/base': 5.0.0-beta.47(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/base': 5.0.0-beta.49(@types/react@18.2.75)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/core-downloads-tracker': 6.0.0-dev.240424162023-9968b4889d
-      '@mui/system': 6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
+      '@mui/system': 6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.75)
-      '@mui/utils': 6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)
+      '@mui/utils': 6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.1
       csstype: 3.1.3
@@ -9691,13 +9693,13 @@ snapshots:
       '@emotion/react': 11.11.4(@types/react@18.2.75)(react@18.2.0)
       '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)
 
-  '@mui/system@6.0.0-alpha.9(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)':
+  '@mui/system@6.0.0-alpha.11(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
       '@mui/private-theming': 6.0.0-dev.20240529-082515-213b5e33ab(@types/react@18.2.75)(react@18.2.0)
       '@mui/styled-engine': 6.0.0-dev.20240529-082515-213b5e33ab(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.2.75)(react@18.2.0))(@types/react@18.2.75)(react@18.2.0))(react@18.2.0)
       '@mui/types': 7.2.14(@types/react@18.2.75)
-      '@mui/utils': 6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)
+      '@mui/utils': 6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -9711,7 +9713,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.75
 
-  '@mui/utils@6.0.0-alpha.9(@types/react@18.2.75)(react@18.2.0)':
+  '@mui/utils@6.0.0-alpha.11(@types/react@18.2.75)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.4
       '@types/prop-types': 15.7.12
@@ -9744,7 +9746,7 @@ snapshots:
 
   '@next/env@13.5.6': {}
 
-  '@next/env@14.2.3': {}
+  '@next/env@14.2.4': {}
 
   '@next/eslint-plugin-next@14.1.4':
     dependencies:
@@ -9753,55 +9755,55 @@ snapshots:
   '@next/swc-darwin-arm64@13.5.6':
     optional: true
 
-  '@next/swc-darwin-arm64@14.2.3':
+  '@next/swc-darwin-arm64@14.2.4':
     optional: true
 
   '@next/swc-darwin-x64@13.5.6':
     optional: true
 
-  '@next/swc-darwin-x64@14.2.3':
+  '@next/swc-darwin-x64@14.2.4':
     optional: true
 
   '@next/swc-linux-arm64-gnu@13.5.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@14.2.3':
+  '@next/swc-linux-arm64-gnu@14.2.4':
     optional: true
 
   '@next/swc-linux-arm64-musl@13.5.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@14.2.3':
+  '@next/swc-linux-arm64-musl@14.2.4':
     optional: true
 
   '@next/swc-linux-x64-gnu@13.5.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@14.2.3':
+  '@next/swc-linux-x64-gnu@14.2.4':
     optional: true
 
   '@next/swc-linux-x64-musl@13.5.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@14.2.3':
+  '@next/swc-linux-x64-musl@14.2.4':
     optional: true
 
   '@next/swc-win32-arm64-msvc@13.5.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@14.2.3':
+  '@next/swc-win32-arm64-msvc@14.2.4':
     optional: true
 
   '@next/swc-win32-ia32-msvc@13.5.6':
     optional: true
 
-  '@next/swc-win32-ia32-msvc@14.2.3':
+  '@next/swc-win32-ia32-msvc@14.2.4':
     optional: true
 
   '@next/swc-win32-x64-msvc@13.5.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@14.2.3':
+  '@next/swc-win32-x64-msvc@14.2.4':
     optional: true
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
@@ -14477,9 +14479,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@14.2.3(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@14.2.4(@babel/core@7.24.4)(@playwright/test@1.43.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@next/env': 14.2.3
+      '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001608
@@ -14489,15 +14491,15 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.1(@babel/core@7.24.4)(react@18.2.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.3
-      '@next/swc-darwin-x64': 14.2.3
-      '@next/swc-linux-arm64-gnu': 14.2.3
-      '@next/swc-linux-arm64-musl': 14.2.3
-      '@next/swc-linux-x64-gnu': 14.2.3
-      '@next/swc-linux-x64-musl': 14.2.3
-      '@next/swc-win32-arm64-msvc': 14.2.3
-      '@next/swc-win32-ia32-msvc': 14.2.3
-      '@next/swc-win32-x64-msvc': 14.2.3
+      '@next/swc-darwin-arm64': 14.2.4
+      '@next/swc-darwin-x64': 14.2.4
+      '@next/swc-linux-arm64-gnu': 14.2.4
+      '@next/swc-linux-arm64-musl': 14.2.4
+      '@next/swc-linux-x64-gnu': 14.2.4
+      '@next/swc-linux-x64-musl': 14.2.4
+      '@next/swc-win32-arm64-msvc': 14.2.4
+      '@next/swc-win32-ia32-msvc': 14.2.4
+      '@next/swc-win32-x64-msvc': 14.2.4
       '@playwright/test': 1.43.0
     transitivePeerDependencies:
       - '@babel/core'

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,0 +1,125 @@
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const glob = require('fast-glob');
+const yargs = require('yargs');
+
+async function run(argv) {
+  const workspaceRoot = path.resolve(__dirname, '../');
+
+  const gitignore = fs.readFileSync(path.join(workspaceRoot, '.gitignore'), { encoding: 'utf8' });
+  const ignore = gitignore
+    .split(/\r?\n/)
+    .filter((pattern) => {
+      return pattern.length > 0 && !pattern.startsWith('#');
+    })
+    .map((line) => {
+      if (line.startsWith('/')) {
+        // "/" marks the cwd of the ignore file.
+        // Since we declare the dirname of the gitignore the cwd we can prepend "." as a shortcut.
+        return `.${line}`;
+      }
+      return line;
+    });
+  const globPattern = `**/*${argv.testFilePattern.replace(/\\/g, '/')}*`;
+  const spec = glob
+    .sync(globPattern, {
+      cwd: workspaceRoot,
+      ignore,
+      followSymbolicLinks: false,
+    })
+    .filter((relativeFile) => {
+      return /\.test\.(js|ts|tsx)$/.test(relativeFile);
+    });
+
+  if (spec.length === 0) {
+    throw new Error(`Could not find any file test files matching '${globPattern}'`);
+  }
+
+  const args = ['mocha'].concat(spec);
+  if (argv.bail) {
+    args.push('--bail');
+  }
+  if (argv.debug || argv.inspecting) {
+    args.push('--timeout 0');
+  }
+  if (argv.debug) {
+    args.push('--inspect-brk');
+  }
+  if (!argv.single) {
+    args.push('--watch');
+  }
+  if (argv.testNamePattern !== undefined) {
+    args.push(`--grep '${argv.testNamePattern}'`);
+  }
+
+  const mochaProcess = childProcess.spawn('pnpm', args, {
+    env: {
+      ...process.env,
+      BABEL_ENV: 'test',
+      NODE_ENV: argv.production ? 'production' : 'test',
+    },
+    shell: true,
+    stdio: ['inherit', 'inherit', 'inherit'],
+  });
+
+  mochaProcess.once('exit', (signal) => {
+    process.exit(signal !== null ? signal : undefined);
+  });
+
+  process.on('SIGINT', () => {
+    // Forward interrupt.
+    // Otherwise cli.js exits and the you get dangling console output from mocha.
+    // "dangling" meaning that you get mocha output in the new terminal input.
+    mochaProcess.kill('SIGINT');
+  });
+}
+
+yargs
+  .command({
+    command: '$0 <testFilePattern>',
+    description: 'Test cli for developing',
+    builder: (command) => {
+      return command
+        .positional('testFilePattern', {
+          description: 'Only test files match "**/*{testFilePattern}*.test.{js,ts,tsx}"',
+          type: 'string',
+        })
+        .option('bail', {
+          alias: 'b',
+          description: 'Stop on first error.',
+          type: 'boolean',
+        })
+        .option('debug', {
+          alias: 'd',
+          description:
+            'Allows attaching a debugger and waits for the debugger to start code execution.',
+          type: 'boolean',
+        })
+        .option('inspecting', {
+          description: 'In case you expect to hit breakpoints that may interrupt a test.',
+          type: 'boolean',
+        })
+        .option('production', {
+          alias: 'p',
+          description:
+            'Run tests in production environment. WARNING: Will not work with most tests.',
+          type: 'boolean',
+        })
+        .option('single', {
+          alias: 's',
+          description: 'Run only once i.e. not in watch mode.',
+          type: 'boolean',
+        })
+        .option('testNamePattern', {
+          alias: 't',
+          description: 'Limit tests by their name given a pattern.',
+          type: 'string',
+        });
+    },
+    handler: run,
+  })
+  .help()
+  .strict(true)
+  .version(false)
+  .parse();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes #142 (`globalCss` is missing from the index)

- added typecheck
- added cli.js from the core to run tests in watch mode with selectable pattern.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
