### PR TITLE
[unplugin] Fix misuse variable to transform libraries

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -171,7 +171,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
       onDone(process.cwd());
     },
     transformInclude(id) {
-      return isZeroRuntimeProcessableFile(id, transformLibraries);
+      return isZeroRuntimeProcessableFile(id, finalTransformLibraries);
     },
     webpack(compiler) {
       const resolverPlugin: ResolvePluginInstance = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Found this bug when trying to export Pigment layout components from Material UI.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
