### PR TITLE
[react] Support transpiled library for `globalCss` and `keyframes`

### DIFF
--- a/packages/pigment-css-react/src/processors/globalCss.ts
+++ b/packages/pigment-css-react/src/processors/globalCss.ts
@@ -134,18 +134,13 @@ export class GlobalCssProcessor extends BaseProcessor {
   }
 
   private handleCall([, callArg]: CallParam, values: ValueCache) {
-    let styleObj: CSSInterpolation;
-    if (callArg.kind === ValueType.LAZY) {
-      styleObj = values.get(callArg.ex.name) as CSSInterpolation;
-    } else if (callArg.kind === ValueType.FUNCTION) {
+    if (callArg.kind === ValueType.LAZY || callArg.kind === ValueType.FUNCTION) {
+      const value = values.get(callArg.ex.name);
       const { themeArgs } = this.options as IOptions;
-      const value = values.get(callArg.ex.name) as (
-        args: Record<string, unknown> | undefined,
-      ) => CSSInterpolation;
-      styleObj = value(themeArgs);
-    }
-    if (styleObj) {
-      this.generateArtifacts(styleObj);
+      const styleObj: CSSInterpolation = typeof value === 'function' ? value(themeArgs) : value;
+      if (styleObj) {
+        this.generateArtifacts(styleObj);
+      }
     }
   }
 

--- a/packages/pigment-css-react/src/processors/keyframes.ts
+++ b/packages/pigment-css-react/src/processors/keyframes.ts
@@ -134,18 +134,13 @@ export class KeyframesProcessor extends BaseProcessor {
   }
 
   private handleCall([, callArg]: CallParam, values: ValueCache) {
-    let styleObj: CSSInterpolation;
-    if (callArg.kind === ValueType.LAZY) {
-      styleObj = values.get(callArg.ex.name) as CSSInterpolation;
-    } else if (callArg.kind === ValueType.FUNCTION) {
+    if (callArg.kind === ValueType.LAZY || callArg.kind === ValueType.FUNCTION) {
+      const value = values.get(callArg.ex.name);
       const { themeArgs } = this.options as IOptions;
-      const value = values.get(callArg.ex.name) as (
-        args: Record<string, unknown> | undefined,
-      ) => CSSInterpolation;
-      styleObj = value(themeArgs);
-    }
-    if (styleObj) {
-      this.generateArtifacts(styleObj);
+      const styleObj: CSSInterpolation = typeof value === 'function' ? value(themeArgs) : value;
+      if (styleObj) {
+        this.generateArtifacts(styleObj);
+      }
     }
   }
 

--- a/packages/pigment-css-react/tests/globalCss/fixtures/globalCss-theme.input.js
+++ b/packages/pigment-css-react/tests/globalCss/fixtures/globalCss-theme.input.js
@@ -28,3 +28,12 @@ let inputGlobalStyles = globalCss(({ theme }) => ({
 if (typeof inputGlobalStyles === 'function') {
   inputGlobalStyles = inputGlobalStyles();
 }
+
+// simulate CssBaseline transpiled by Next.js
+export const styles = (theme) => ({
+  html: {
+    color: theme.palette.primary.main,
+  },
+});
+const GlobalStyles = globalCss((_c = ({ theme }) => styles(theme)));
+var _c;

--- a/packages/pigment-css-react/tests/globalCss/fixtures/globalCss-theme.output.css
+++ b/packages/pigment-css-react/tests/globalCss/fixtures/globalCss-theme.output.css
@@ -25,3 +25,6 @@
     color: red;
   }
 }
+html {
+  color: red;
+}

--- a/packages/pigment-css-react/tests/globalCss/fixtures/globalCss-theme.output.js
+++ b/packages/pigment-css-react/tests/globalCss/fixtures/globalCss-theme.output.js
@@ -3,3 +3,12 @@ let inputGlobalStyles = null;
 if (typeof inputGlobalStyles === 'function') {
   inputGlobalStyles = inputGlobalStyles();
 }
+
+// simulate CssBaseline transpiled by Next.js
+export const styles = (theme) => ({
+  html: {
+    color: theme.palette.primary.main,
+  },
+});
+const GlobalStyles = null;
+var _c;

--- a/packages/pigment-css-react/tests/keyframes/fixtures/keyframes-theme.input.js
+++ b/packages/pigment-css-react/tests/keyframes/fixtures/keyframes-theme.input.js
@@ -27,3 +27,18 @@ const gradientKeyframe2 = keyframes`
     background: ${({ theme }) => theme.palette.secondary.main};
   }
 `;
+
+// simulate CssBaseline transpiled by Next.js
+export const styles = (theme) => ({
+  '0%': {
+    background: theme.palette.primary.main,
+  },
+  '50%': {
+    background: green,
+  },
+  '100%': {
+    background: theme.palette.secondary.main,
+  },
+});
+const gradientKeyframe3 = keyframes((_c = ({ theme }) => styles(theme)));
+var _c;

--- a/packages/pigment-css-react/tests/keyframes/fixtures/keyframes-theme.output.css
+++ b/packages/pigment-css-react/tests/keyframes/fixtures/keyframes-theme.output.css
@@ -20,3 +20,14 @@
     background: blue;
   }
 }
+@keyframes g9lh2y5 {
+  0% {
+    background: red;
+  }
+  50% {
+    background: green;
+  }
+  100% {
+    background: blue;
+  }
+}

--- a/packages/pigment-css-react/tests/keyframes/fixtures/keyframes-theme.output.js
+++ b/packages/pigment-css-react/tests/keyframes/fixtures/keyframes-theme.output.js
@@ -1,2 +1,18 @@
+const green = 'green';
 const gradientKeyframe = 'gpsum18';
 const gradientKeyframe2 = 'g1t1dgxp';
+
+// simulate CssBaseline transpiled by Next.js
+export const styles = (theme) => ({
+  '0%': {
+    background: theme.palette.primary.main,
+  },
+  '50%': {
+    background: green,
+  },
+  '100%': {
+    background: theme.palette.secondary.main,
+  },
+});
+const gradientKeyframe3 = 'g9lh2y5';
+var _c;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Found this bug from https://github.com/mui/material-ui/pull/42640

## Root cause

The code of CssBaseline looks like this:

```js
const GlobalStyles = globalCss(({ theme }) => styles(theme));
```

However, after building Material UI as a package and Next.js import it, the code before passing to Pigment is:

```js
const GlobalStyles = globalCss(_c = ({
  theme
}) => styles(theme));
_c1 = GlobalStyles;
var c1;
```

Notice that the value passed to `globalCss` is a variable instead of a function. Pigment CSS thinks that it's not a function, that's why the CSS does not generated (with Emotion error):

```
Functions that are interpolated in css calls will be stringified.
If you want to have a css call based on props, create a function that returns a css call like this
let dynamicStyle = (props) => css`color: ${props.color}`
It can be called directly with props or interpolated in a styled call like this
let SomeComponent = styled('div')`${dynamicStyle}`
```

The fix is simple, we check the type after the evaluation and then pass the theme if it's a function.

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
