### PR TITLE
[nextjs] Make library path check OS agnostic

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -114,9 +114,9 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
     css,
     ...rest
   } = options;
-  const finalTransformLibraries = transformLibraries.concat(
-    process.env.RUNTIME_PACKAGE_NAME as string,
-  );
+  const finalTransformLibraries = transformLibraries
+    .concat(process.env.RUNTIME_PACKAGE_NAME as string)
+    .map((lib) => lib.split('/').join(path.sep));
   const cache = new TransformCacheCollection();
   const { emitter, onDone } = createFileReporter(debug ?? false);
   const cssLookup = meta?.type === 'next' ? globalCssLookup : new Map<string, string>();

--- a/packages/pigment-css-vite-plugin/src/index.ts
+++ b/packages/pigment-css-vite-plugin/src/index.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import type { Plugin } from 'vite';
 import {
   preprocessor as basePreprocessor,
@@ -46,9 +47,9 @@ export function pigment(options: PigmentOptions) {
     css,
     ...rest
   } = options ?? {};
-  const finalTransformLibraries = transformLibraries.concat(
-    process.env.RUNTIME_PACKAGE_NAME as string,
-  );
+  const finalTransformLibraries = transformLibraries
+    .concat(process.env.RUNTIME_PACKAGE_NAME as string)
+    .map((lib) => lib.split('/').join(path.sep));
 
   function injectMUITokensPlugin(): Plugin {
     return {


### PR DESCRIPTION
This makes sure to check for scoped packages name in the path using OS specific path separator.

Fixes https://github.com/mui/material-ui/pull/42693

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
