### PR TITLE
[core] Replace global JSX

### DIFF
--- a/apps/local-ui-lib/index.d.ts
+++ b/apps/local-ui-lib/index.d.ts
@@ -1,6 +1,8 @@
+import type * as React from 'react';
+
 export const bounceAnim: string;
 export const Button: React.ComponentType<
-  JSX.IntrinsicElements['button'] & {
+  React.JSX.IntrinsicElements['button'] & {
     isRed?: boolean;
     sx?: unknown;
   }

--- a/packages/pigment-css-react/src/Box.d.ts
+++ b/packages/pigment-css-react/src/Box.d.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react';
 import type { BaseDefaultProps, Substitute, NoInfer } from './base';
 import type { SxProp } from './sx';
 
@@ -33,7 +34,7 @@ export interface PolymorphicComponent<BaseProps extends BaseDefaultProps>
   extends React.ForwardRefExoticComponent<BaseProps> {
   <AsTarget extends React.ElementType | undefined = undefined>(
     props: PolymorphicComponentProps<BaseProps, AsTarget>,
-  ): JSX.Element;
+  ): React.JSX.Element;
 }
 
 declare const Box: PolymorphicComponent<{}>;

--- a/packages/pigment-css-react/src/base.ts
+++ b/packages/pigment-css-react/src/base.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react';
 import type * as CSS from 'csstype';
 import { OverridableStringUnion } from '@mui/types';
 
@@ -63,7 +64,7 @@ export interface PolymorphicComponent<SxProp, BaseProps extends BaseDefaultProps
   extends React.ForwardRefExoticComponent<BaseProps> {
   <AsTarget extends React.ElementType | undefined = undefined>(
     props: PolymorphicComponentProps<SxProp, BaseProps, AsTarget>,
-  ): JSX.Element;
+  ): React.JSX.Element;
 }
 
 export interface BreakpointOverrides {}

--- a/packages/pigment-css-react/src/styled.d.ts
+++ b/packages/pigment-css-react/src/styled.d.ts
@@ -70,7 +70,7 @@ export interface CreateStyled {
 }
 
 export type CreateStyledIndex = {
-  [Key in keyof JSX.IntrinsicElements]: CreateStyledComponent<Key, JSX.IntrinsicElements[Key]>;
+  [Key in keyof React.JSX.IntrinsicElements]: CreateStyledComponent<Key, React.JSX.IntrinsicElements[Key]>;
 };
 
 declare const styled: CreateStyled & CreateStyledIndex;

--- a/packages/pigment-css-react/src/styled.d.ts
+++ b/packages/pigment-css-react/src/styled.d.ts
@@ -70,7 +70,10 @@ export interface CreateStyled {
 }
 
 export type CreateStyledIndex = {
-  [Key in keyof React.JSX.IntrinsicElements]: CreateStyledComponent<Key, React.JSX.IntrinsicElements[Key]>;
+  [Key in keyof React.JSX.IntrinsicElements]: CreateStyledComponent<
+    Key,
+    React.JSX.IntrinsicElements[Key]
+  >;
 };
 
 declare const styled: CreateStyled & CreateStyledIndex;


### PR DESCRIPTION
Replace global `JSX` with `React.JSX` to prepare for upcoming `@types/react` version which [removes global `JSX`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022#:~:text=No%20replacement-,JSX%20Namespace,-A%20long%2Dtime).

This is required for https://github.com/mui/material-ui/pull/42824.