### PR TITLE
`ownerState` type safety in `variants`

### DIFF
--- a/packages/pigment-css-react/src/styled.d.ts
+++ b/packages/pigment-css-react/src/styled.d.ts
@@ -6,8 +6,8 @@ import { Primitve } from './keyframes';
 
 type Falsy = false | 0 | '' | null | undefined;
 
-export interface StyledVariants<Props extends BaseDefaultProps> {
-  props: Partial<Props> | ((props: Props) => boolean);
+export interface StyledVariants<Props extends BaseDefaultProps & { ownerState?: object }> {
+  props: Partial<Props> | Partial<Props['ownerState']> | ((props: Props) => boolean);
   style: CSSObject<Props>;
 }
 


### PR DESCRIPTION
This would allow to type safely use `ownerState`'s properties in `styled`'s `variants` without providing a callback.

The problem is that now the example below works as intended (a new class name is correctly applied when `rounded` is `true`), but the compiler complains because it doesn't know anything about `ownerState`'s type (only props overall).

```typescript

import { styled } from '@pigment-css/react';

const StyledDiv = styled('div')<{ ownerState: { rounded: boolean } }>(
  {
    backgroundColor: 'blue',
    variants: [
      { props: { rounded: true }, style: { borderRadius: 8 } },
    ],
  },
);

function App() {
  return <StyledDiv ownerState={{ rounded: true }}>div</StyledDiv>;
}

export default App;
```

Or maybe I misunderstood something and `ownerState` isn't supposed to be used without a callback.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
