### PR TITLE
[core] Fix thrown error during eval phase

### DIFF
--- a/apps/pigment-css-next-app/src/app/grid/page.tsx
+++ b/apps/pigment-css-next-app/src/app/grid/page.tsx
@@ -13,7 +13,7 @@ const Item = styled.div`
 
 function GridDemo1() {
   return (
-    <Grid container spacing={2}>
+    <Grid container spacing={2} sx={{ color: '#070707' }}>
       <Grid size={8}>
         <Item>size=8</Item>
       </Grid>

--- a/packages/pigment-css-react/src/css.js
+++ b/packages/pigment-css-react/src/css.js
@@ -1,4 +1,12 @@
+/**
+ * `__wyw_dynamic_import` is a special global var that is set during the evaluation phase by wyw.
+ * So during eval phase, it can happen that some code is calling the runtime function.
+ * We do not want to throw error in that case as we want the evaluation to happen.
+ */
 export default function css() {
+  if (typeof __wyw_dynamic_import !== 'undefined') {
+    return;
+  }
   throw new Error(
     `${process.env.PACKAGE_NAME}: You were trying to call "css" function without configuring your bundler. Make sure to install the bundler specific plugin and use it. @pigment-css/vite-plugin for Vite integration or @pigment-css/nextjs-plugin for Next.js integration.`,
   );

--- a/packages/pigment-css-react/src/generateAtomics.js
+++ b/packages/pigment-css-react/src/generateAtomics.js
@@ -1,6 +1,14 @@
 import cx from 'clsx';
 
+/**
+ * `__wyw_dynamic_import` is a special global var that is set during the evaluation phase by wyw.
+ * So during eval phase, it can happen that some code is calling the runtime function.
+ * We do not want to throw error in that case as we want the evaluation to happen.
+ */
 export function generateAtomics() {
+  if (typeof __wyw_dynamic_import !== 'undefined') {
+    return;
+  }
   throw new Error(
     `${process.env.PACKAGE_NAME}: You were trying to call "generateAtomics" function without configuring your bundler. Make sure to install the bundler specific plugin and use it. @pigment-css/vite-plugin for Vite integration or @pigment-css/nextjs-plugin for Next.js integration.`,
   );

--- a/packages/pigment-css-react/src/globalCss.js
+++ b/packages/pigment-css-react/src/globalCss.js
@@ -1,4 +1,12 @@
+/**
+ * `__wyw_dynamic_import` is a special global var that is set during the evaluation phase by wyw.
+ * So during eval phase, it can happen that some code is calling the runtime function.
+ * We do not want to throw error in that case as we want the evaluation to happen.
+ */
 export default function globalCss() {
+  if (typeof __wyw_dynamic_import !== 'undefined') {
+    return;
+  }
   throw new Error(
     `${process.env.PACKAGE_NAME}: You were trying to call "globalCss" function without configuring your bundler. Make sure to install the bundler specific plugin and use it. @pigment-css/vite-plugin for Vite integration or @pigment-css/nextjs-plugin for Next.js integration.`,
   );

--- a/packages/pigment-css-react/src/keyframes.js
+++ b/packages/pigment-css-react/src/keyframes.js
@@ -1,4 +1,12 @@
+/**
+ * `__wyw_dynamic_import` is a special global var that is set during the evaluation phase by wyw.
+ * So during eval phase, it can happen that some code is calling the runtime function.
+ * We do not want to throw error in that case as we want the evaluation to happen.
+ */
 export default function keyframes() {
+  if (typeof __wyw_dynamic_import !== 'undefined') {
+    return;
+  }
   throw new Error(
     `${process.env.PACKAGE_NAME}: You were trying to call "keyframes" function without configuring your bundler. Make sure to install the bundler specific plugin and use it. @pigment-css/vite-plugin for Vite integration or @pigment-css/nextjs-plugin for Next.js integration.`,
   );

--- a/packages/pigment-css-react/src/useTheme.js
+++ b/packages/pigment-css-react/src/useTheme.js
@@ -1,4 +1,12 @@
+/**
+ * `__wyw_dynamic_import` is a special global var that is set during the evaluation phase by wyw.
+ * So during eval phase, it can happen that some code is calling the runtime function.
+ * We do not want to throw error in that case as we want the evaluation to happen.
+ */
 export default function useTheme() {
+  if (typeof __wyw_dynamic_import !== 'undefined') {
+    return;
+  }
   throw new Error(
     `${process.env.PACKAGE_NAME}: You were trying to call "useTheme" function without configuring your bundler. Make sure to install the bundler specific plugin and use it. @pigment-css/vite-plugin for Vite integration or @pigment-css/nextjs-plugin for Next.js integration.`,
   );


### PR DESCRIPTION
This PR changes the way we throw errors for our top-level exported functions. With the introduction of our build-time container components, we also started using the top-level APIs in these components. This in itself is ok since we don't want any restrictions. But this lead to an issue where an error was thrown, typically if trying to add sx prop on such container components (1 example).
This was because these container component files were also being evaluated during the eval phase of wyw and that phase also included calls to generateAtomics which always throws error. So with this change, we first detect whether the function is being called during the eval phase or not, by checking a special global variable called `__wyw_dynamic_import` which is set by WyW before evaluation happens. So now these functions don't throw error during the eval stage.

Fixes #193 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
