### PR TITLE
[typescript] Fix `sx` types

### DIFF
--- a/packages/pigment-css-react/src/sx.d.ts
+++ b/packages/pigment-css-react/src/sx.d.ts
@@ -1,9 +1,11 @@
 import type { CSSObjectNoCallback } from './base';
 import type { ThemeArgs } from './theme';
 
+type GetTheme<Argument> = Argument extends { theme: infer Theme } ? Theme : never;
+
 export type SxProp =
   | CSSObjectNoCallback
-  | ((themeArgs: ThemeArgs['theme']) => CSSObjectNoCallback)
-  | ReadonlyArray<CSSObjectNoCallback | ((themeArgs: ThemeArgs['theme']) => CSSObjectNoCallback)>;
+  | ((theme: GetTheme<ThemeArgs>) => CSSObjectNoCallback)
+  | ReadonlyArray<CSSObjectNoCallback | ((theme: GetTheme<ThemeArgs>) => CSSObjectNoCallback)>;
 
-export default function sx(arg: SxProp | Array<SxProp>, componentClass?: string): string;
+export default function sx(arg: SxProp, componentClass?: string): string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Issue

This [previous fix](https://github.com/mui/pigment-css/pull/191) causes Material UI build fails because the `SxProp` tries to get `theme` from an empty `ThemeArgs`.

The reason that Pigment CSS did not catch the error in [the PR](https://github.com/mui/pigment-css/pull/191) is because the project has augmented the theme types in `index.spec.ts` which causes the build to pass.

Will need to move all spec in a separate test environment so that it catches errors like this before merging.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
