### PR TITLE
docs(readme): add missing `className` to an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Pigment CSS replaces the callback with a CSS variable and injects the value thr
 
 ```jsx
 <h1
+  className="Heading_class_akjsdfb"
   style={{
     '--Heading_class_akjsdfb-0': isError ? 'red' : 'black',
   }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

In the [readme section about ‘Styling based on runtime values’](https://github.com/mui/pigment-css/blob/5cb469a1dc0e2d6950f5a21f07e411dbc0bba1cc/README.md#styling-based-on-runtime-values), the resulting `className` is missing from the transformation example.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
