### PR TITLE
[plugin] Fix bug related to path separator on Windows

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -219,7 +219,10 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
       compiler.options.resolve.plugins.push(resolverPlugin);
     },
     async transform(code, filePath) {
-      const [id] = filePath.split('?');
+      const [pathSegment] = filePath.split('?');
+      // Converts path separator as per platform, even on Windows, path segments have `/` instead of the usual `\`,
+      // so this function replaces such path separators.
+      const id = path.normalize(pathSegment);
       const transformServices = {
         options: {
           filename: id,
@@ -314,7 +317,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
         if (isNext) {
           const data = `${meta.placeholderCssFile}?${encodeURIComponent(
             JSON.stringify({
-              filename: id.split('/').pop(),
+              filename: id.split(path.sep).pop(),
               source: cssText.replaceAll('!important', '__IMP__'),
             }),
           )}`;

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -218,11 +218,11 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
       compiler.options.resolve.plugins = compiler.options.resolve.plugins || [];
       compiler.options.resolve.plugins.push(resolverPlugin);
     },
-    async transform(code, filePath) {
-      const [pathSegment] = filePath.split('?');
+    async transform(code, url) {
+      const [filePath] = url.split('?');
       // Converts path separator as per platform, even on Windows, path segments have `/` instead of the usual `\`,
       // so this function replaces such path separators.
-      const id = path.normalize(pathSegment);
+      const id = path.normalize(filePath);
       const transformServices = {
         options: {
           filename: id,

--- a/packages/pigment-css-vite-plugin/src/vite-plugin.ts
+++ b/packages/pigment-css-vite-plugin/src/vite-plugin.ts
@@ -132,17 +132,19 @@ export default function wywVitePlugin({
         .filter((m): m is ModuleNode => !!m);
     },
     async transform(code, url) {
-      const [id] = url.split('?', 1);
-
+      const [filePath] = url.split('?', 1);
+      // Converts path separator as per platform, even on Windows, path segments have `/` instead of the usual `\`,
+      // so this function replaces such path separators.
+      const id = path.normalize(filePath);
       // Main modification starts
       if (id in cssLookup) {
         return null;
       }
 
-      let shouldReturn = url.includes('node_modules');
+      let shouldReturn = id.includes('node_modules');
 
       if (shouldReturn) {
-        shouldReturn = !transformLibraries.some((libName: string) => url.includes(libName));
+        shouldReturn = !transformLibraries.some((libName: string) => id.includes(libName));
       }
 
       if (shouldReturn) {
@@ -151,7 +153,7 @@ export default function wywVitePlugin({
       // Main modification end
 
       // Do not transform ignored and generated files
-      if (!filter(url)) {
+      if (!filter(id)) {
         return null;
       }
 
@@ -282,7 +284,7 @@ export default function wywVitePlugin({
 
         for (let i = 0, end = dependencies.length; i < end; i += 1) {
           // eslint-disable-next-line no-await-in-loop
-          const depModule = await this.resolve(dependencies[i], url, {
+          const depModule = await this.resolve(dependencies[i], id, {
             isEntry: false,
           });
           if (depModule) {


### PR DESCRIPTION
While debugging on Windows, I found that (atleast on Windows 11), the path separator was `/` instead of the expected `\` resulting in some files being skipped from being transformed from the `node_modules`.

So the fix first normalizes the path as per the platform and then checks for the `transformLibraries`'s presence in the normalized path.

Fixes - https://github.com/mui/material-ui/issues/43487

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
