### PR TITLE
[system] Add recent change in function name to patch

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -91,6 +91,7 @@ const addMaterialUIOverriedContext = (originalContext: Record<string, unknown>) 
         __esModule: true,
         default: () => () => () => null,
         internal_processStyles: () => {},
+        internal_serializeStyles: () => {},
         keyframes: () => '',
         css: () => '',
       };

--- a/packages/pigment-css-vite-plugin/src/vite-plugin.ts
+++ b/packages/pigment-css-vite-plugin/src/vite-plugin.ts
@@ -49,6 +49,7 @@ const addMaterialUIOverriedContext = (originalContext: Record<string, unknown>) 
         __esModule: true,
         default: () => () => () => null,
         internal_processStyles: () => {},
+        internal_serializeStyles: () => {},
         keyframes: () => '',
         css: () => '',
       };


### PR DESCRIPTION
The internal export has been renamed from `internal_processStyles` to `internal_serializeStyles` in a recent [PR](https://github.com/mui/material-ui/pull/43412) resulting in build failures. This change fixes that. Ideally, this should be moved to the core repo so that similar changes in future do not require a fix in this repo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
