### PR TITLE
[core] Pin GitHub action dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           # fetch all tags which are required for `pnpm release:changelog`
           fetch-depth: 0
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
       - name: Use Node.js 18.x
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:


### PR DESCRIPTION
Fix https://github.com/mui/pigment-css/security/code-scanning/11. Copy the code of Material UI https://github.com/mui/material-ui/blob/ffddc915a083d4921a75d4c3573185a6b3388e22/.github/workflows/ci.yml#L32.

Arf the CI is red, fixing that in #222.