### PR TITLE
[core] Fix CI with fake docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,5 +11,6 @@
   NODE_VERSION = "18"
   PNPM_FLAGS = "--shamefully-hoist"
 
-[[plugins]]
-  package = "./packages/netlify-plugin-cache-docs"
+# TODO uncomment once we have a docs website.
+# [[plugins]]
+#  package = "./packages/netlify-plugin-cache-docs"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "release:publish": "pnpm publish --recursive --tag latest",
     "release:publish:dry-run": "pnpm publish --recursive --tag latest --registry=\"http://localhost:4873/\"",
     "release:tag": "node scripts/releaseTag.mjs",
+    "docs:build": "rm -rf docs && mkdir -p docs/export && touch docs/export/index.html",
     "extract-error-codes": "cross-env MUI_EXTRACT_ERROR_CODES=true lerna run --concurrency 8 build:modern",
     "install:codesandbox": "pnpm install --no-frozen-lockfile",
     "jsonlint": "node ./scripts/jsonlint.mjs",


### PR DESCRIPTION
I got confused why my build in #221 failed, so here is a fix, so I get only green checks in https://github.com/pulls.

Preview: https://deploy-preview-222--pigment-css.netlify.app/