### PR TITLE
[next] Wrap all generated CSS with a cascade layer (WIP)

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -284,6 +284,15 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
         }
 
         let { cssText } = result;
+
+        const slug = slugify(cssText);
+
+        cssText = `
+          @layer _${slug} {
+            ${cssText}
+          } 
+        `;
+
         if (isNext && !outputCss) {
           return {
             code: result.code,
@@ -324,7 +333,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
         }
 
         const rootPath = process.cwd();
-        const slug = slugify(cssText);
+
         const cssFilename = path
           .normalize(`${id.replace(/\.[jt]sx?$/, '')}-${slug}.pigment.css`)
           .replace(/\\/g, path.posix.sep);

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -26,7 +26,6 @@ import {
 } from '@pigment-css/react/utils';
 import type { ResolvePluginInstance } from 'webpack';
 import { styledEngineMockup } from '@pigment-css/react/internal';
-
 import { handleUrlReplacement, type AsyncResolver } from './utils';
 
 type NextMeta = {
@@ -287,10 +286,14 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
 
         const slug = slugify(cssText);
 
+        // Valid names must start with a underscore or letter.
+        const layerName = `_${slug}`;
+
+        // TODO: Do this in a way that keeps the source map correct
         cssText = `
-          @layer _${slug} {
+          @layer pigment.${layerName} {
             ${cssText}
-          } 
+          }
         `;
 
         if (isNext && !outputCss) {

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -286,16 +286,6 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
 
         const slug = slugify(cssText);
 
-        // Valid names must start with a underscore or letter.
-        const layerName = `_${slug}`;
-
-        // TODO: Do this in a way that keeps the source map correct
-        cssText = `
-          @layer pigment.${layerName} {
-            ${cssText}
-          }
-        `;
-
         if (isNext && !outputCss) {
           return {
             code: result.code,
@@ -310,6 +300,19 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
           if (cssText && cssText.includes('url(')) {
             cssText = await handleUrlReplacement(cssText, id, asyncResolve, projectPath);
           }
+
+          // Valid names must start with a underscore or letter.
+          const layerName = `_${slug}`;
+
+          // Fix for https://github.com/mui/pigment-css/issues/199
+          // Bring each file in its own layer so that the order is maintained between css modules
+          // shared between layout.tsx and page.tsx.
+          // TODO: Do this in a way that keeps the source map correct
+          cssText = `
+            @layer pigment.${layerName} {
+              ${cssText}
+            }
+          `;
         }
 
         if (sourceMap && result.cssSourceMapText) {


### PR DESCRIPTION
One way to fix https://github.com/mui/pigment-css/issues/199

* Updated [stackblitz](https://stackblitz.com/edit/github-xv6opg-fggtsn?file=package.json) for https://github.com/mui/pigment-css/issues/199
* Updated [codesandbox](https://codesandbox.io/p/github/wh5938316/mui-v6-pigment-css/csb-ymg78v/draft/floral-dream) for https://github.com/mui/material-ui/issues/43529.


Notes:

* Does this have unwanted side-effects?
* TODO: sourcemaps. Can we get away with them shifting down 1 line for the sake of a quick fix? => let's run with it for now.
* Does this belong in `wyw-in-js`?


Closes https://github.com/mui/material-ui/pull/43705