### PR TITLE
[nextjs] Move the import startsWith next check at end

### DIFF
--- a/packages/pigment-css-nextjs-plugin/src/index.ts
+++ b/packages/pigment-css-nextjs-plugin/src/index.ts
@@ -73,7 +73,12 @@ export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptio
           // Need to point to the react from node_modules during eval time.
           // Otherwise, next makes it point to its own version of react that
           // has a lot of RSC specific logic which is not actually needed.
-          if (what.startsWith('@babel') || what.startsWith('react') || what.startsWith('next')) {
+          if (
+            what === 'react' ||
+            what.startsWith('react-dom/') ||
+            what.startsWith('@babel/') ||
+            what.startsWith('next/')
+          ) {
             return require.resolve(what);
           }
           if (asyncResolve) {

--- a/packages/pigment-css-nextjs-plugin/src/index.ts
+++ b/packages/pigment-css-nextjs-plugin/src/index.ts
@@ -61,13 +61,7 @@ export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptio
           if (what.startsWith('__barrel_optimize__')) {
             return require.resolve('../next-font');
           }
-          // Need to point to the react from node_modules during eval time.
-          // Otherwise, next makes it point to its own version of react that
-          // has a lot of RSC specific logic which is not actually needed.
-          if (what.startsWith('@babel') || what.startsWith('react') || what.startsWith('next')) {
-            return require.resolve(what);
-          }
-          if (what === 'next/image') {
+          if (what === 'next/image' || what === 'next/link') {
             return require.resolve('../next-image');
           }
           if (what.startsWith('next/font')) {
@@ -75,6 +69,12 @@ export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptio
           }
           if (what.startsWith('@emotion/styled') || what.startsWith('styled-components')) {
             return require.resolve('../third-party-styled');
+          }
+          // Need to point to the react from node_modules during eval time.
+          // Otherwise, next makes it point to its own version of react that
+          // has a lot of RSC specific logic which is not actually needed.
+          if (what.startsWith('@babel') || what.startsWith('react') || what.startsWith('next')) {
+            return require.resolve(what);
           }
           if (asyncResolve) {
             return asyncResolve(what, importer, stack);

--- a/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
+++ b/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
@@ -155,10 +155,6 @@ function iterateAndReplaceFunctions(
   const css = styleObj as StyleObj;
   Object.keys(css).forEach((key) => {
     const value = css[key];
-    if (!value) {
-      // ignore null value
-      return;
-    }
 
     if (typeof value === 'object') {
       if (!Array.isArray(value)) {

--- a/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
+++ b/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
@@ -155,6 +155,10 @@ function iterateAndReplaceFunctions(
   const css = styleObj as StyleObj;
   Object.keys(css).forEach((key) => {
     const value = css[key];
+    if (!value) {
+      // ignore null value
+      return;
+    }
 
     if (typeof value === 'object') {
       if (!Array.isArray(value)) {


### PR DESCRIPTION
* This fixes the resolve error happening in nextjs for it's path based module imports.
* Also adds check for `next/link`
* Ignore null value during css object processing

Fixes #204 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
