### PR TITLE
[Grid] ignore RSC error

### DIFF
--- a/packages/pigment-css-react/src/Grid.jsx
+++ b/packages/pigment-css-react/src/Grid.jsx
@@ -8,10 +8,16 @@ import { generateAtomics } from './generateAtomics';
 import styled from './styled';
 
 function isGridComponent(element) {
-  // For server components `muiName` is avaialble in element.type._payload.value.muiName
-  // relevant info - https://github.com/facebook/react/blob/2807d781a08db8e9873687fccc25c0f12b4fb3d4/packages/react/src/ReactLazy.js#L45
-  // eslint-disable-next-line no-underscore-dangle
-  return element.type.muiName === 'Grid' || element.type?._payload?.value?.muiName === 'Grid';
+  try {
+    // For server components `muiName` is avaialble in element.type._payload.value.muiName
+    // relevant info - https://github.com/facebook/react/blob/2807d781a08db8e9873687fccc25c0f12b4fb3d4/packages/react/src/ReactLazy.js#L45
+    // eslint-disable-next-line no-underscore-dangle
+    return element.type.muiName === 'Grid' || element.type?._payload?.value?.muiName === 'Grid';
+  } catch (error) {
+    // Covers for the case in which the Grid is a server component and the child is a client component
+    // https://github.com/mui/material-ui/issues/43635
+    return false;
+  }
 }
 
 const gridAtomics = generateAtomics(({ theme }) => {

--- a/packages/pigment-css-react/tests/Grid/fixtures/Grid.output.js
+++ b/packages/pigment-css-react/tests/Grid/fixtures/Grid.output.js
@@ -7,10 +7,16 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 function isGridComponent(element) {
-  // For server components `muiName` is avaialble in element.type._payload.value.muiName
-  // relevant info - https://github.com/facebook/react/blob/2807d781a08db8e9873687fccc25c0f12b4fb3d4/packages/react/src/ReactLazy.js#L45
-  // eslint-disable-next-line no-underscore-dangle
-  return element.type.muiName === 'Grid' || element.type?._payload?.value?.muiName === 'Grid';
+  try {
+    // For server components `muiName` is avaialble in element.type._payload.value.muiName
+    // relevant info - https://github.com/facebook/react/blob/2807d781a08db8e9873687fccc25c0f12b4fb3d4/packages/react/src/ReactLazy.js#L45
+    // eslint-disable-next-line no-underscore-dangle
+    return element.type.muiName === 'Grid' || element.type?._payload?.value?.muiName === 'Grid';
+  } catch (error) {
+    // Covers for the case in which the Grid is a server component and the child is a client component
+    // https://github.com/mui/material-ui/issues/43635
+    return false;
+  }
 }
 const gridAtomics = /*#__PURE__*/ _atomics({
   styles: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

closes https://github.com/mui/material-ui/issues/43635

This is a temporary fix, which might not cover an edge case if the consumer use client component as a child of Grid container.

However, this fix should work for normal use cases because a Grid container should always have Grid item.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
