### PR TITLE
[react] Fix css extraction for transformed styled tagged-template call

### DIFF
--- a/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.input.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.input.js
@@ -1,0 +1,88 @@
+/**
+ * This is a pre-transformed file for testing.
+ */
+import { _ as _tagged_template_literal } from "@swc/helpers/_/_tagged_template_literal";
+import { styled, keyframes } from '@pigment-css/react';
+
+function _templateObject() {
+    const data = _tagged_template_literal(["\n  0% {\n    transform: scale(0);\n    opacity: 0.1;\n  }\n\n  100% {\n    transform: scale(1);\n    opacity: 0.3;\n  }\n"]);
+    _templateObject = function () {
+        return data;
+    };
+    return data;
+}
+function _templateObject1() {
+    const data = _tagged_template_literal(["\n  0% {\n    opacity: 1;\n  }\n\n  100% {\n    opacity: 0;\n  }\n"]);
+    _templateObject1 = function () {
+        return data;
+    };
+    return data;
+}
+function _templateObject2() {
+    const data = _tagged_template_literal(["\n  0% {\n    transform: scale(1);\n  }\n\n  50% {\n    transform: scale(0.92);\n  }\n\n  100% {\n    transform: scale(1);\n  }\n"]);
+    _templateObject2 = function () {
+        return data;
+    };
+    return data;
+}
+function _templateObject3() {
+    const data = _tagged_template_literal(["\n  opacity: 0;\n  position: absolute;\n\n  &.", " {\n    opacity: 0.3;\n    transform: scale(1);\n    animation-name: ", ";\n    animation-duration: ", "ms;\n    animation-timing-function: ", ";\n  }\n\n  &.", " {\n    animation-duration: ", "ms;\n  }\n\n  & .", " {\n    opacity: 1;\n    display: block;\n    width: 100%;\n    height: 100%;\n    border-radius: 50%;\n    background-color: currentColor;\n  }\n\n  & .", " {\n    opacity: 0;\n    animation-name: ", ";\n    animation-duration: ", "ms;\n    animation-timing-function: ", ";\n  }\n\n  & .", " {\n    position: absolute;\n    /* @noflip */\n    left: 0px;\n    top: 0;\n    animation-name: ", ";\n    animation-duration: 2500ms;\n    animation-timing-function: ", ";\n    animation-iteration-count: infinite;\n    animation-delay: 200ms;\n  }\n"]);
+    _templateObject3 = function () {
+        return data;
+    };
+    return data;
+}
+
+const touchRippleClasses = {
+    rippleVisible: 'MuiTouchRipple.rippleVisible',
+    ripplePulsate: 'MuiTouchRipple.ripplePulsate',
+    child: 'MuiTouchRipple.child',
+    childLeaving: 'MuiTouchRipple.childLeaving',
+    childPulsate: 'MuiTouchRipple.childPulsate',
+};
+
+const enterKeyframe = keyframes(_templateObject());
+const exitKeyframe = keyframes(_templateObject1());
+const pulsateKeyframe = keyframes(_templateObject2());
+
+export const TouchRippleRoot = styled('span', {
+    name: 'MuiTouchRipple',
+    slot: 'Root'
+})({
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    position: 'absolute',
+    zIndex: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    borderRadius: 'inherit'
+});
+
+// This `styled()` function invokes keyframes. `styled-components` only supports keyframes
+// in string templates. Do not convert these styles in JS object as it will break.
+export const TouchRippleRipple = styled(Ripple, {
+    name: 'MuiTouchRipple',
+    slot: 'Ripple'
+})(_templateObject3(), touchRippleClasses.rippleVisible, enterKeyframe, DURATION, param => {
+    let {
+        theme
+    } = param;
+    return theme.transitions.easing.easeInOut;
+}, touchRippleClasses.ripplePulsate, param => {
+    let {
+        theme
+    } = param;
+    return theme.transitions.duration.shorter;
+}, touchRippleClasses.child, touchRippleClasses.childLeaving, exitKeyframe, DURATION, param => {
+    let {
+        theme
+    } = param;
+    return theme.transitions.easing.easeInOut;
+}, touchRippleClasses.childPulsate, pulsateKeyframe, param => {
+    let {
+        theme
+    } = param;
+    return theme.transitions.easing.easeInOut;
+});

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.output.css
@@ -1,0 +1,78 @@
+@keyframes e19ejdhp {
+  0% {
+    transform: scale(0);
+    opacity: 0.1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0.3;
+  }
+}
+@keyframes e1rvu9kp {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+@keyframes p1yhz964 {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(0.92);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+.ttz155n {
+  overflow: hidden;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: inherit;
+}
+.tm7990f {
+  opacity: 0;
+  position: absolute;
+}
+.tm7990f.MuiTouchRipple.rippleVisible {
+  opacity: 0.3;
+  transform: scale(1);
+  animation-name: e19ejdhp;
+  animation-duration: ms;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+.tm7990f.MuiTouchRipple.ripplePulsate {
+  animation-duration: 200ms;
+}
+.tm7990f .MuiTouchRipple.child {
+  opacity: 1;
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: currentColor;
+}
+.tm7990f .MuiTouchRipple.childLeaving {
+  opacity: 0;
+  animation-name: e1rvu9kp;
+  animation-duration: ms;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+.tm7990f .MuiTouchRipple.childPulsate {
+  position: absolute;
+  left: 0px;
+  top: 0;
+  animation-name: p1yhz964;
+  animation-duration: 2500ms;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  animation-iteration-count: infinite;
+  animation-delay: 200ms;
+}

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.output.js
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.output.js
@@ -1,0 +1,21 @@
+import { styled as _styled, styled as _styled2 } from '@pigment-css/react';
+import _theme from '@pigment-css/react/theme';
+/**
+ * This is a pre-transformed file for testing.
+ */
+export const TouchRippleRoot = /*#__PURE__*/ _styled('span', {
+  name: 'MuiTouchRipple',
+  slot: 'Root',
+})({
+  classes: ['ttz155n'],
+});
+
+// This `styled()` function invokes keyframes. `styled-components` only supports keyframes
+// in string templates. Do not convert these styles in JS object as it will break.
+const _exp6 = /*#__PURE__*/ () => Ripple;
+export const TouchRippleRipple = /*#__PURE__*/ _styled2(_exp6(), {
+  name: 'MuiTouchRipple',
+  slot: 'Ripple',
+})({
+  classes: ['tm7990f'],
+});

--- a/packages/pigment-css-react/tests/styled/styled.test.tsx
+++ b/packages/pigment-css-react/tests/styled/styled.test.tsx
@@ -154,4 +154,36 @@ describe('Pigment CSS - styled', () => {
     expect(output.js).to.equal(fixture.js);
     expect(output.css).to.equal(fixture.css);
   });
+
+  it('should properly transform a pre-transform tagged-template styled call', async () => {
+    const { output, fixture } = await runTransformation(
+      path.join(__dirname, 'fixtures/styled-swc-transformed-tagged-string.input.js'),
+      {
+        themeArgs: {
+          theme: {
+            transitions: {
+              easing: {
+                easeInOut: 'cubic-bezier(0.4, 0, 0.2, 1)',
+                easeOut: 'cubic-bezier(0.0, 0, 0.2, 1)',
+                easeIn: 'cubic-bezier(0.4, 0, 1, 1)',
+                sharp: 'cubic-bezier(0.4, 0, 0.6, 1)',
+              },
+              duration: {
+                shortest: 150,
+                shorter: 200,
+                short: 250,
+                standard: 300,
+                complex: 375,
+                enteringScreen: 225,
+                leavingScreen: 195,
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(output.js).to.equal(fixture.js);
+    expect(output.css).to.equal(fixture.css);
+  });
 });

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -116,7 +116,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
     theme,
     meta,
     transformLibraries = [],
-    preprocessor,
+    preprocessor = basePreprocessor,
     asyncResolve: asyncResolveOpt,
     debug = false,
     sourceMap = false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

1. Fixes https://github.com/mui/material-ui/issues/43619
2. Also adds default preprocessor in `unplugin` package.

The main issue here is that `next.js` through `swc` transpiles files in `node_modules` which also includes tagged template literals, converting them to a normal `styled()()` with somewhat weird arguments.
This transformation was not handled previously resulting in some missing css from the final output.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
