### PR TITLE
[nextjs] Fix react import check bug introduced in #228

### DIFF
--- a/packages/pigment-css-nextjs-plugin/src/index.ts
+++ b/packages/pigment-css-nextjs-plugin/src/index.ts
@@ -75,6 +75,7 @@ export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptio
           // has a lot of RSC specific logic which is not actually needed.
           if (
             what === 'react' ||
+            what.startsWith('react/') ||
             what.startsWith('react-dom/') ||
             what.startsWith('@babel/') ||
             what.startsWith('next/')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Adds a check for imports starting with `react/` as well besides `react` which fixes imports like `react/jsx-runtime`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
