### PR TITLE
[react] Wrap individual css output into their own cascade layer

### DIFF
--- a/packages/pigment-css-react/src/processors/styled.ts
+++ b/packages/pigment-css-react/src/processors/styled.ts
@@ -249,7 +249,7 @@ export class StyledProcessor extends BaseProcessor {
 
     const baseClass = this.getClassName();
     this.baseClasses.push(baseClass);
-    this.collectedStyles.push([baseClass, cssText, null]);
+    this.collectedStyles.push([baseClass, `@layer pigment.base {${cssText}}`, null]);
     const variantsAccumulator: VariantData[] = [];
     this.processOverrides(values, variantsAccumulator);
     variantsAccumulator.forEach((variant) => {
@@ -521,7 +521,11 @@ export class StyledProcessor extends BaseProcessor {
   ) {
     if (styleArg.kind === ValueType.CONST) {
       if (typeof styleArg.value === 'string') {
-        this.collectedStyles.push([this.getClassName(), styleArg.value, styleArg]);
+        this.collectedStyles.push([
+          this.getClassName(),
+          `@layer pigment.base {${styleArg.value}}`,
+          styleArg,
+        ]);
       }
     } else {
       const styleObjOrFn = values.get(styleArg.ex.name);
@@ -533,7 +537,7 @@ export class StyledProcessor extends BaseProcessor {
       );
       const className = this.getClassName();
       this.baseClasses.push(className);
-      this.collectedStyles.push([className, finalStyle, styleArg]);
+      this.collectedStyles.push([className, `@layer pigment.base {${finalStyle}}`, styleArg]);
     }
   }
 
@@ -563,12 +567,12 @@ export class StyledProcessor extends BaseProcessor {
         overrides[value.slot]) as string | CSSObject;
       const className = this.getClassName();
       if (typeof overrideStyle === 'string') {
-        this.collectedStyles.push([className, overrideStyle, null]);
+        this.collectedStyles.push([className, `@layer pigment.override {${overrideStyle}}`, null]);
         return;
       }
       const finalStyle = this.processCss(overrideStyle, null, variantsAccumulator);
       this.baseClasses.push(className);
-      this.collectedStyles.push([className, finalStyle, null]);
+      this.collectedStyles.push([className, `@layer pigment.override {${finalStyle}}`, null]);
     }
 
     if (!variantsAccumulator) {
@@ -593,7 +597,7 @@ export class StyledProcessor extends BaseProcessor {
     const styleObjOrFn = variant.style;
     const originalExpression = variant.originalExpression;
     const finalStyle = this.processCss(styleObjOrFn, originalExpression ?? null);
-    this.collectedStyles.push([className, finalStyle, null]);
+    this.collectedStyles.push([className, `@layer pigment.variant {${finalStyle}}`, null]);
     this.collectedVariants.push({
       props: variant.props,
       className,

--- a/packages/pigment-css-react/src/processors/sx.ts
+++ b/packages/pigment-css-react/src/processors/sx.ts
@@ -60,7 +60,7 @@ export class SxProcessor extends BaseProcessor {
     const rules: Rules = {
       [this.asSelector]: {
         className: this.className,
-        cssText,
+        cssText: `@layer pigment.sx {${cssText}}`,
         displayName: this.displayName,
         start: this.location?.start ?? null,
       },

--- a/packages/pigment-css-react/src/utils/generateCss.ts
+++ b/packages/pigment-css-react/src/utils/generateCss.ts
@@ -7,7 +7,7 @@ export function generateTokenCss(theme?: Theme) {
   }
   // use emotion to serialize the object to css string
   const { styles } = serializeStyles(theme.generateStyleSheets?.() || []);
-  return styles;
+  return `@layer pigment.base, pigment.variant, pigment.override, pigment.sx;${styles}`;
 }
 
 export function generateThemeTokens(theme?: Theme) {

--- a/packages/pigment-css-react/tests/Box/fixtures/box-jsx.output.css
+++ b/packages/pigment-css-react/tests/Box/fixtures/box-jsx.output.css
@@ -1,13 +1,17 @@
-.sd5jss7 {
-  margin: 0;
-  margin-block: 1rem;
-  padding: 0;
-  padding-left: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+@layer pigment.sx {
+  .sd5jss7 {
+    margin: 0;
+    margin-block: 1rem;
+    padding: 0;
+    padding-left: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
 }
-.sk625fs {
-  display: flex;
-  flex-direction: column;
+@layer pigment.sx {
+  .sk625fs {
+    display: flex;
+    flex-direction: column;
+  }
 }

--- a/packages/pigment-css-react/tests/Box/fixtures/box.output.css
+++ b/packages/pigment-css-react/tests/Box/fixtures/box.output.css
@@ -1,10 +1,12 @@
-.bc1d15y {
-  color: var(--bc1d15y-0);
-  margin: 0;
-  margin-block: 1rem;
-  padding: 0;
-  padding-left: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+@layer pigment.sx {
+  .bc1d15y {
+    color: var(--bc1d15y-0);
+    margin: 0;
+    margin-block: 1rem;
+    padding: 0;
+    padding-left: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
 }

--- a/packages/pigment-css-react/tests/Container/fixtures/Container.output.css
+++ b/packages/pigment-css-react/tests/Container/fixtures/Container.output.css
@@ -1,61 +1,77 @@
-.c12mgz3n {
-  width: 100%;
-  margin-left: auto;
-  box-sizing: border-box;
-  margin-right: auto;
+@layer pigment.base {
+  .c12mgz3n {
+    width: 100%;
+    margin-left: auto;
+    box-sizing: border-box;
+    margin-right: auto;
+  }
 }
-.c12mgz3n-1 {
-  padding-left: 16px;
-  padding-right: 16px;
-}
-@media (min-width: 600px) {
+@layer pigment.variant {
   .c12mgz3n-1 {
-    padding-left: 24px;
-    padding-right: 24px;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  @media (min-width: 600px) {
+    .c12mgz3n-1 {
+      padding-left: 24px;
+      padding-right: 24px;
+    }
   }
 }
-@media (min-width: 600px) {
-  .c12mgz3n-2 {
-    max-width: 600px;
+@layer pigment.variant {
+  @media (min-width: 600px) {
+    .c12mgz3n-2 {
+      max-width: 600px;
+    }
+  }
+  @media (min-width: 900px) {
+    .c12mgz3n-2 {
+      max-width: 900px;
+    }
+  }
+  @media (min-width: 1200px) {
+    .c12mgz3n-2 {
+      max-width: 1200px;
+    }
+  }
+  @media (min-width: 1536px) {
+    .c12mgz3n-2 {
+      max-width: 1536px;
+    }
   }
 }
-@media (min-width: 900px) {
-  .c12mgz3n-2 {
-    max-width: 900px;
+@layer pigment.variant {
+  @media (min-width: 0px) {
+    .c12mgz3n-3 {
+      max-width: 444px;
+    }
   }
 }
-@media (min-width: 1200px) {
-  .c12mgz3n-2 {
-    max-width: 1200px;
+@layer pigment.variant {
+  @media (min-width: 600px) {
+    .c12mgz3n-4 {
+      max-width: 600px;
+    }
   }
 }
-@media (min-width: 1536px) {
-  .c12mgz3n-2 {
-    max-width: 1536px;
+@layer pigment.variant {
+  @media (min-width: 900px) {
+    .c12mgz3n-5 {
+      max-width: 900px;
+    }
   }
 }
-@media (min-width: 0px) {
-  .c12mgz3n-3 {
-    max-width: 444px;
+@layer pigment.variant {
+  @media (min-width: 1200px) {
+    .c12mgz3n-6 {
+      max-width: 1200px;
+    }
   }
 }
-@media (min-width: 600px) {
-  .c12mgz3n-4 {
-    max-width: 600px;
-  }
-}
-@media (min-width: 900px) {
-  .c12mgz3n-5 {
-    max-width: 900px;
-  }
-}
-@media (min-width: 1200px) {
-  .c12mgz3n-6 {
-    max-width: 1200px;
-  }
-}
-@media (min-width: 1536px) {
-  .c12mgz3n-7 {
-    max-width: 1536px;
+@layer pigment.variant {
+  @media (min-width: 1536px) {
+    .c12mgz3n-7 {
+      max-width: 1536px;
+    }
   }
 }

--- a/packages/pigment-css-react/tests/Grid/fixtures/Grid.output.css
+++ b/packages/pigment-css-react/tests/Grid/fixtures/Grid.output.css
@@ -343,35 +343,50 @@
     --Grid-self-margin-left: var(--Grid-self-margin-left-xl);
   }
 }
-.g1i5ygey {
-  --Grid-fixed-width: calc(
-    100% * var(--Grid-self-column-span) / var(--Grid-parent-column-count) -
-      (var(--Grid-parent-column-count) - var(--Grid-self-column-span)) *
-      var(--Grid-parent-column-spacing) / var(--Grid-parent-column-count)
-  );
-  --Grid-fixed-offset: calc(
-    100% * var(--Grid-self-offset) / var(--Grid-parent-column-count) +
-      var(--Grid-parent-column-spacing) * var(--Grid-self-offset) / var(--Grid-parent-column-count)
-  );
+@layer pigment.base {
+  .g1i5ygey {
+    --Grid-fixed-width: calc(
+      100% * var(--Grid-self-column-span) / var(--Grid-parent-column-count) -
+        (var(--Grid-parent-column-count) - var(--Grid-self-column-span)) *
+        var(--Grid-parent-column-spacing) / var(--Grid-parent-column-count)
+    );
+    --Grid-fixed-offset: calc(
+      100% * var(--Grid-self-offset) / var(--Grid-parent-column-count) +
+        var(--Grid-parent-column-spacing) * var(--Grid-self-offset) /
+        var(--Grid-parent-column-count)
+    );
+  }
 }
-.g1i5ygey-1 {
-  display: flex;
-  gap: var(--Grid-self-row-spacing) var(--Grid-self-column-spacing);
+@layer pigment.variant {
+  .g1i5ygey-1 {
+    display: flex;
+    gap: var(--Grid-self-row-spacing) var(--Grid-self-column-spacing);
+  }
 }
-.g1i5ygey-2 {
-  width: var(--Grid-self-width);
-  max-width: var(--Grid-self-max-width);
-  flex: var(--Grid-self-flex);
+@layer pigment.variant {
+  .g1i5ygey-2 {
+    width: var(--Grid-self-width);
+    max-width: var(--Grid-self-max-width);
+    flex: var(--Grid-self-flex);
+  }
 }
-.g1i5ygey-3 {
-  margin-left: var(--Grid-self-margin-left);
+@layer pigment.variant {
+  .g1i5ygey-3 {
+    margin-left: var(--Grid-self-margin-left);
+  }
 }
-.g1i5ygey-4 {
-  flex-wrap: nowrap;
+@layer pigment.variant {
+  .g1i5ygey-4 {
+    flex-wrap: nowrap;
+  }
 }
-.g1i5ygey-5 {
-  flex-wrap: wrap-reverse;
+@layer pigment.variant {
+  .g1i5ygey-5 {
+    flex-wrap: wrap-reverse;
+  }
 }
-.g1i5ygey-6 {
-  flex-wrap: wrap;
+@layer pigment.variant {
+  .g1i5ygey-6 {
+    flex-wrap: wrap;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-import-replacement.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-import-replacement.output.css
@@ -6,18 +6,24 @@
     transform: translateX(100%);
   }
 }
-.ci0148v {
-  animation: rrqhzm2 2s ease-out 0s infinite;
-  margin-left: 10px;
+@layer pigment.base {
+  .ci0148v {
+    animation: rrqhzm2 2s ease-out 0s infinite;
+    margin-left: 10px;
+  }
 }
-.suo5xob {
-  display: block;
-  position: absolute;
-  left: 0;
-  top: 0;
-  border-top-left-radius: 3px;
+@layer pigment.base {
+  .suo5xob {
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    border-top-left-radius: 3px;
+  }
 }
-.sudpq9z .suo5xob {
-  padding-inline-start: none;
-  margin: 0px 10px 10px 30px;
+@layer pigment.base {
+  .sudpq9z .suo5xob {
+    padding-inline-start: none;
+    margin: 0px 10px 10px 30px;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-rtl.output.css
@@ -6,39 +6,55 @@
     transform: translateX(100%);
   }
 }
-.c194j3ko {
-  animation: r14vlhb 2s ease-out 0s infinite;
-  margin-left: 10px;
+@layer pigment.base {
+  .c194j3ko {
+    animation: r14vlhb 2s ease-out 0s infinite;
+    margin-left: 10px;
+  }
 }
-:dir(rtl) .c194j3ko {
-  animation: r14vlhb 2s ease-out 0s infinite;
-  margin-right: 10px;
+@layer pigment.base {
+  :dir(rtl) .c194j3ko {
+    animation: r14vlhb 2s ease-out 0s infinite;
+    margin-left: 10px;
+  }
 }
-.sgip8u5 {
-  display: block;
-  position: absolute;
-  left: 0;
-  top: 0;
-  border-top-left-radius: 3px;
+@layer pigment.base {
+  .sgip8u5 {
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    border-top-left-radius: 3px;
+  }
 }
-:dir(rtl) .sgip8u5 {
-  display: block;
-  position: absolute;
-  right: 0;
-  top: 0;
-  border-top-right-radius: 3px;
+@layer pigment.base {
+  :dir(rtl) .sgip8u5 {
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    border-top-left-radius: 3px;
+  }
 }
-.sgip8u5-1 {
-  font-size: 1.5rem;
+@layer pigment.override {
+  .sgip8u5-1 {
+    font-size: 1.5rem;
+  }
 }
-:dir(rtl) .sgip8u5-1 {
-  font-size: 1.5rem;
+@layer pigment.override {
+  :dir(rtl) .sgip8u5-1 {
+    font-size: 1.5rem;
+  }
 }
-.smip3v5 .sgip8u5 {
-  padding-inline-start: none;
-  margin: 0px 10px 10px 30px;
+@layer pigment.base {
+  .smip3v5 .sgip8u5 {
+    padding-inline-start: none;
+    margin: 0px 10px 10px 30px;
+  }
 }
-:dir(rtl) .smip3v5 .sgip8u5 {
-  padding-inline-start: none;
-  margin: 0px 30px 10px 10px;
+@layer pigment.base {
+  :dir(rtl) .smip3v5 .sgip8u5 {
+    padding-inline-start: none;
+    margin: 0px 10px 10px 30px;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-swc-transformed-tagged-string.output.css
@@ -27,52 +27,56 @@
     transform: scale(1);
   }
 }
-.ttz155n {
-  overflow: hidden;
-  pointer-events: none;
-  position: absolute;
-  z-index: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  border-radius: inherit;
+@layer pigment.base {
+  .ttz155n {
+    overflow: hidden;
+    pointer-events: none;
+    position: absolute;
+    z-index: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border-radius: inherit;
+  }
 }
-.tm7990f {
-  opacity: 0;
-  position: absolute;
-}
-.tm7990f.MuiTouchRipple.rippleVisible {
-  opacity: 0.3;
-  transform: scale(1);
-  animation-name: e19ejdhp;
-  animation-duration: ms;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-.tm7990f.MuiTouchRipple.ripplePulsate {
-  animation-duration: 200ms;
-}
-.tm7990f .MuiTouchRipple.child {
-  opacity: 1;
-  display: block;
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  background-color: currentColor;
-}
-.tm7990f .MuiTouchRipple.childLeaving {
-  opacity: 0;
-  animation-name: e1rvu9kp;
-  animation-duration: ms;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-.tm7990f .MuiTouchRipple.childPulsate {
-  position: absolute;
-  left: 0px;
-  top: 0;
-  animation-name: p1yhz964;
-  animation-duration: 2500ms;
-  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  animation-iteration-count: infinite;
-  animation-delay: 200ms;
+@layer pigment.base {
+  .tm7990f {
+    opacity: 0;
+    position: absolute;
+  }
+  .tm7990f.MuiTouchRipple.rippleVisible {
+    opacity: 0.3;
+    transform: scale(1);
+    animation-name: e19ejdhp;
+    animation-duration: ms;
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .tm7990f.MuiTouchRipple.ripplePulsate {
+    animation-duration: 200ms;
+  }
+  .tm7990f .MuiTouchRipple.child {
+    opacity: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-color: currentColor;
+  }
+  .tm7990f .MuiTouchRipple.childLeaving {
+    opacity: 0;
+    animation-name: e1rvu9kp;
+    animation-duration: ms;
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .tm7990f .MuiTouchRipple.childPulsate {
+    position: absolute;
+    left: 0px;
+    top: 0;
+    animation-name: p1yhz964;
+    animation-duration: 2500ms;
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    animation-iteration-count: infinite;
+    animation-delay: 200ms;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-theme-styleOverrides.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-theme-styleOverrides.output.css
@@ -1,6 +1,10 @@
-.njazm0b {
-  border-color: red;
+@layer pigment.base {
+  .njazm0b {
+    border-color: red;
+  }
 }
-.njazm0b-1 {
-  border: none;
+@layer pigment.override {
+  .njazm0b-1 {
+    border: none;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-theme-styleOverrides2.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-theme-styleOverrides2.output.css
@@ -1,21 +1,35 @@
-.o1ei225m {
-  padding: 16.5px 14px;
+@layer pigment.base {
+  .o1ei225m {
+    padding: 16.5px 14px;
+  }
 }
-.o1ei225m-1 {
-  padding: 8.5px 14px;
+@layer pigment.variant {
+  .o1ei225m-1 {
+    padding: 8.5px 14px;
+  }
 }
-.o1ei225m-2 {
-  padding: 0;
+@layer pigment.variant {
+  .o1ei225m-2 {
+    padding: 0;
+  }
 }
-.o1ei225m-3 {
-  padding-left: 0;
+@layer pigment.variant {
+  .o1ei225m-3 {
+    padding-left: 0;
+  }
 }
-.o1ei225m-4 {
-  padding-right: 0;
+@layer pigment.variant {
+  .o1ei225m-4 {
+    padding-right: 0;
+  }
 }
-.o1ei225m-5 {
-  padding-left: 10px;
+@layer pigment.override {
+  .o1ei225m-5 {
+    padding-left: 10px;
+  }
 }
-.o1ei225m-6 {
-  padding: 9px 14.5px;
+@layer pigment.variant {
+  .o1ei225m-6 {
+    padding: 9px 14.5px;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-theme.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-theme.output.css
@@ -6,32 +6,42 @@
     transform: rotate(0deg);
   }
 }
-.c1h7nuob {
-  color: red;
-  animation: rnit1sq 2s ease-out 0s infinite;
+@layer pigment.base {
+  .c1h7nuob {
+    color: red;
+    animation: rnit1sq 2s ease-out 0s infinite;
+  }
 }
-.s13xim6i {
-  display: block;
-  position: absolute;
-  border-radius: inherit;
-  background-color: currentColor;
-  opacity: 0.38;
-  font-size: 3rem;
+@layer pigment.base {
+  .s13xim6i {
+    display: block;
+    position: absolute;
+    border-radius: inherit;
+    background-color: currentColor;
+    opacity: 0.38;
+    font-size: 3rem;
+  }
 }
-.s13xim6i-1 {
-  font-size: 1.5rem;
+@layer pigment.override {
+  .s13xim6i-1 {
+    font-size: 1.5rem;
+  }
 }
-.s1emg10t {
-  display: block;
-  opacity: 0.38;
-  font-size: 3rem;
+@layer pigment.base {
+  .s1emg10t {
+    display: block;
+    opacity: 0.38;
+    font-size: 3rem;
+  }
+  .s1emg10t .s13xim6i {
+    display: none;
+  }
 }
-.s1emg10t .s13xim6i {
-  display: none;
-}
-.o1l8bn4d {
-  padding: 16.5px 14px;
-}
-.o1l8bn4d:-webkit-autofill {
-  border-radius: inherit;
+@layer pigment.base {
+  .o1l8bn4d {
+    padding: 16.5px 14px;
+  }
+  .o1l8bn4d:-webkit-autofill {
+    border-radius: inherit;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled-variants.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled-variants.output.css
@@ -1,6 +1,10 @@
-.b1prasel-1 {
-  color: tomato;
+@layer pigment.variant {
+  .b1prasel-1 {
+    color: tomato;
+  }
 }
-.b1prasel-2 {
-  color: salmon;
+@layer pigment.variant {
+  .b1prasel-2 {
+    color: salmon;
+  }
 }

--- a/packages/pigment-css-react/tests/styled/fixtures/styled.output.css
+++ b/packages/pigment-css-react/tests/styled/fixtures/styled.output.css
@@ -6,21 +6,27 @@
     transform: rotate(0deg);
   }
 }
-.c1aiqtje {
-  color: #ff5252;
-  animation: r1sz5zcv 2s ease-out 0s infinite;
+@layer pigment.base {
+  .c1aiqtje {
+    color: #ff5252;
+    animation: r1sz5zcv 2s ease-out 0s infinite;
+  }
 }
-.sj0zd45 {
-  display: block;
-  position: absolute;
-  border-radius: inherit;
-  background-color: currentColor;
-  opacity: 0.38;
+@layer pigment.base {
+  .sj0zd45 {
+    display: block;
+    position: absolute;
+    border-radius: inherit;
+    background-color: currentColor;
+    opacity: 0.38;
+  }
 }
-.shdkmm7 {
-  display: block;
-  opacity: 0.38;
-}
-.shdkmm7 .sj0zd45 {
-  display: none;
+@layer pigment.base {
+  .shdkmm7 {
+    display: block;
+    opacity: 0.38;
+  }
+  .shdkmm7 .sj0zd45 {
+    display: none;
+  }
 }

--- a/packages/pigment-css-react/tests/sx/fixtures/sx-array.output.css
+++ b/packages/pigment-css-react/tests/sx/fixtures/sx-array.output.css
@@ -1,49 +1,81 @@
-.dnf03uj {
-  opacity: 1;
+@layer pigment.sx {
+  .dnf03uj {
+    opacity: 1;
+  }
 }
-.dsvwfmp {
-  color: red;
+@layer pigment.sx {
+  .dsvwfmp {
+    color: red;
+  }
 }
-.d121rcfp {
-  color: green;
+@layer pigment.sx {
+  .d121rcfp {
+    color: green;
+  }
 }
-.schfkcb {
-  color: var(--schfkcb-0);
+@layer pigment.sx {
+  .schfkcb {
+    color: var(--schfkcb-0);
+  }
 }
-.s1cp79ho {
-  background-color: blue;
-  color: white;
+@layer pigment.sx {
+  .s1cp79ho {
+    background-color: blue;
+    color: white;
+  }
 }
-.soyt4ij {
-  border: 1px solid red;
+@layer pigment.sx {
+  .soyt4ij {
+    border: 1px solid red;
+  }
 }
-.sr48wd1 {
-  color: green;
+@layer pigment.sx {
+  .sr48wd1 {
+    color: green;
+  }
 }
-.s6s70bv {
-  color: var(--s6s70bv-0);
+@layer pigment.sx {
+  .s6s70bv {
+    color: var(--s6s70bv-0);
+  }
 }
-.s1v8upwb {
-  opacity: 1;
+@layer pigment.sx {
+  .s1v8upwb {
+    opacity: 1;
+  }
 }
-.sjtfjpx {
-  color: red;
+@layer pigment.sx {
+  .sjtfjpx {
+    color: red;
+  }
 }
-.s1r80n7h {
-  color: green;
+@layer pigment.sx {
+  .s1r80n7h {
+    color: green;
+  }
 }
-.s1gu7ed8 {
-  border: 1px solid red;
+@layer pigment.sx {
+  .s1gu7ed8 {
+    border: 1px solid red;
+  }
 }
-.s1h4vmh2 {
-  opacity: 0.4;
+@layer pigment.sx {
+  .s1h4vmh2 {
+    opacity: 0.4;
+  }
 }
-.s1oy2sl1 {
-  color: red;
+@layer pigment.sx {
+  .s1oy2sl1 {
+    color: red;
+  }
 }
-.s14d8kn5 {
-  border: 1px solid red;
+@layer pigment.sx {
+  .s14d8kn5 {
+    border: 1px solid red;
+  }
 }
-.s1su4mia {
-  color: var(--s1su4mia-0);
+@layer pigment.sx {
+  .s1su4mia {
+    color: var(--s1su4mia-0);
+  }
 }

--- a/packages/pigment-css-react/tests/sx/fixtures/sx-jsx.output.css
+++ b/packages/pigment-css-react/tests/sx/fixtures/sx-jsx.output.css
@@ -1,47 +1,63 @@
-.s5molx8 {
-  display: flex;
-  flex-direction: column;
-}
-.s7fszdm {
-  display: flex;
-  flex-direction: column;
-}
-.s2bbd3t {
-  color: red;
-}
-@media (prefers-color-scheme: dark) {
-  .s2bbd3t {
-    color: white;
+@layer pigment.sx {
+  .s5molx8 {
+    display: flex;
+    flex-direction: column;
   }
 }
-.s1ou6jyi {
-  opacity: 0.4;
+@layer pigment.sx {
+  .s7fszdm {
+    display: flex;
+    flex-direction: column;
+  }
 }
-.s1lqy6hu {
-  color: red;
+@layer pigment.sx {
+  .s2bbd3t {
+    color: red;
+  }
+  @media (prefers-color-scheme: dark) {
+    .s2bbd3t {
+      color: white;
+    }
+  }
 }
-.swssabr {
-  color: var(--swssabr-0);
+@layer pigment.sx {
+  .s1ou6jyi {
+    opacity: 0.4;
+  }
 }
-.sblg7d5 {
-  border: none;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+@layer pigment.sx {
+  .s1lqy6hu {
+    color: red;
+  }
 }
-.s1xq3929 {
-  border: none;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+@layer pigment.sx {
+  .swssabr {
+    color: var(--swssabr-0);
+  }
+}
+@layer pigment.sx {
+  .sblg7d5 {
+    border: none;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}
+@layer pigment.sx {
+  .s1xq3929 {
+    border: none;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
 }

--- a/packages/pigment-css-react/tests/sx/fixtures/sx-shorthand.output.css
+++ b/packages/pigment-css-react/tests/sx/fixtures/sx-shorthand.output.css
@@ -1,4 +1,6 @@
-.d1h14by3 {
-  color: var(--d1h14by3-0);
-  mb: 1px;
+@layer pigment.sx {
+  .d1h14by3 {
+    color: var(--d1h14by3-0);
+    mb: 1px;
+  }
 }

--- a/packages/pigment-css-react/tests/sx/fixtures/sxProps.output.css
+++ b/packages/pigment-css-react/tests/sx/fixtures/sxProps.output.css
@@ -1,50 +1,68 @@
-.sjfloo5 {
-  display: block;
-  position: absolute;
-  border-radius: inherit;
-  background-color: currentColor;
-  opacity: 0.38;
-  font-size: 3rem;
+@layer pigment.base {
+  .sjfloo5 {
+    display: block;
+    position: absolute;
+    border-radius: inherit;
+    background-color: currentColor;
+    opacity: 0.38;
+    font-size: 3rem;
+  }
 }
-.sjfloo5-1 {
-  font-size: 3rem;
+@layer pigment.override {
+  .sjfloo5-1 {
+    font-size: 3rem;
+  }
 }
-.s1o8xp19 {
-  color: red;
+@layer pigment.sx {
+  .s1o8xp19 {
+    color: red;
+  }
 }
-.s1xbsywq {
-  color: var(--s1xbsywq-0);
+@layer pigment.sx {
+  .s1xbsywq {
+    color: var(--s1xbsywq-0);
+  }
 }
-.s1wnk6s5 {
-  background-color: blue;
-  color: white;
+@layer pigment.sx {
+  .s1wnk6s5 {
+    background-color: blue;
+    color: white;
+  }
 }
-.stzaibv {
-  color: var(--stzaibv-0);
+@layer pigment.sx {
+  .stzaibv {
+    color: var(--stzaibv-0);
+  }
 }
-.sazg8ol {
-  margin-bottom: 1px;
-  text-align: center;
+@layer pigment.sx {
+  .sazg8ol {
+    margin-bottom: 1px;
+    text-align: center;
+  }
 }
-.s1v3ec1v {
-  border: none;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+@layer pigment.sx {
+  .s1v3ec1v {
+    border: none;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
 }
-.s1ojh0i1 {
-  border: none;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+@layer pigment.sx {
+  .s1ojh0i1 {
+    border: none;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
 }

--- a/packages/pigment-css-react/tests/sx/fixtures/sxProps2.output.css
+++ b/packages/pigment-css-react/tests/sx/fixtures/sxProps2.output.css
@@ -1,35 +1,45 @@
-.sdbmcs3 {
-  display: block;
-  position: absolute;
-  border-radius: inherit;
-  background-color: currentColor;
-  opacity: 0.38;
-  font-size: 3rem;
-}
-.sdbmcs3-1 {
-  font-size: 3rem;
-}
-.si7ulc4 {
-  mb: 1px;
-}
-@media (prefers-color-scheme: dark) {
-  .si7ulc4 {
-    color: white;
+@layer pigment.base {
+  .sdbmcs3 {
+    display: block;
+    position: absolute;
+    border-radius: inherit;
+    background-color: currentColor;
+    opacity: 0.38;
+    font-size: 3rem;
   }
 }
-.sliig2s {
-  border-radius: 8px;
-  margin: 5px;
+@layer pigment.override {
+  .sdbmcs3-1 {
+    font-size: 3rem;
+  }
 }
-.sliig2s.MuiAutocomplete-option {
-  padding: 8px;
+@layer pigment.sx {
+  .si7ulc4 {
+    mb: 1px;
+  }
+  @media (prefers-color-scheme: dark) {
+    .si7ulc4 {
+      color: white;
+    }
+  }
 }
-.so956n {
-  color: red;
-  font-size: var(--so956n-0);
+@layer pigment.sx {
+  .sliig2s {
+    border-radius: 8px;
+    margin: 5px;
+  }
+  .sliig2s.MuiAutocomplete-option {
+    padding: 8px;
+  }
 }
-.so956n :hover {
-  background-color: rgb(0, 255, 0);
-  background-color: color(display-p3 0 1 0);
-  color: rgb(0, 255, 0);
+@layer pigment.sx {
+  .so956n {
+    color: red;
+    font-size: var(--so956n-0);
+  }
+  .so956n :hover {
+    background-color: rgb(0, 255, 0);
+    background-color: color(display-p3 0 1 0);
+    color: rgb(0, 255, 0);
+  }
 }

--- a/packages/pigment-css-react/tests/theme/fixtures/themed-component.output.css
+++ b/packages/pigment-css-react/tests/theme/fixtures/themed-component.output.css
@@ -1,21 +1,29 @@
-.si9gu6v {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  background-color: #ebf5ff;
-  border-radius: 0.25rem;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  letter-spacing: -0.025em;
-  font-weight: 600;
+@layer pigment.base {
+  .si9gu6v {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    background-color: #ebf5ff;
+    border-radius: 0.25rem;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    letter-spacing: -0.025em;
+    font-weight: 600;
+  }
 }
-.si9gu6v-1 {
-  border: 2px solid #e9e9e9;
+@layer pigment.variant {
+  .si9gu6v-1 {
+    border: 2px solid #e9e9e9;
+  }
 }
-.sbfbm5t {
-  font-size: 2rem;
+@layer pigment.base {
+  .sbfbm5t {
+    font-size: 2rem;
+  }
 }
-.s1xscf0o {
-  font-size: 1rem;
-  color: #6f7f95;
+@layer pigment.base {
+  .s1xscf0o {
+    font-size: 1rem;
+    color: #6f7f95;
+  }
 }

--- a/packages/pigment-css-react/tests/utils/theme-tokens.test.ts
+++ b/packages/pigment-css-react/tests/utils/theme-tokens.test.ts
@@ -12,7 +12,7 @@ describe('theme-tokens', () => {
           },
           fontSizes: [12, 14, 16, 20, 24, 32],
         }),
-      ).to.equal('');
+      ).to.equal('@layer pigment.base, pigment.variant, pigment.override, pigment.sx;');
     });
 
     it('should generate stylesheet correctly', () => {
@@ -41,7 +41,7 @@ describe('theme-tokens', () => {
           }),
         ),
       ).to.equal(
-        ':root{--radius-xs:4px;--radius-sm:8px;--radius-md:16px;}:root{--palette-primary:red;--palette-secondary:blue;}@media (prefers-color-scheme: dark){:root{--palette-primary:darkred;--palette-secondary:darkblue;}}',
+        '@layer pigment.base, pigment.variant, pigment.override, pigment.sx;:root{--radius-xs:4px;--radius-sm:8px;--radius-md:16px;}:root{--palette-primary:red;--palette-secondary:blue;}@media (prefers-color-scheme: dark){:root{--palette-primary:darkred;--palette-secondary:darkblue;}}',
       );
     });
   });

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -302,17 +302,17 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
           }
 
           // Valid names must start with a underscore or letter.
-          const layerName = `_${slug}`;
+          // const layerName = `_${slug}`;
 
-          // Fix for https://github.com/mui/pigment-css/issues/199
-          // Bring each file in its own layer so that the order is maintained between css modules
-          // shared between layout.tsx and page.tsx.
-          // TODO: Do this in a way that keeps the source map correct
-          cssText = `
-            @layer pigment.${layerName} {
-              ${cssText}
-            }
-          `;
+          // // Fix for https://github.com/mui/pigment-css/issues/199
+          // // Bring each file in its own layer so that the order is maintained between css modules
+          // // shared between layout.tsx and page.tsx.
+          // // TODO: Do this in a way that keeps the source map correct
+          // cssText = `
+          //   @layer pigment.${layerName} {
+          //     ${cssText}
+          //   }
+          // `;
         }
 
         if (sourceMap && result.cssSourceMapText) {


### PR DESCRIPTION
Also, update the base style output to include pigment cascade layer order.

This change wraps the CSS output into its own layers and then the base css style output determines the precedence of the layers.

Lets assume this to be kind of an RFC PR to discuss the usage and impact of Cascade layers.

One immediate downside I see is increase in generated CSS size since each individual css output is wrapped in a layer.
Endusers might need to include a PostCSS plugin to merge layers,media queries and classNames.

This fixes #199 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
