### PR TITLE
[core] Increase the minimum Node.js version support to 14.0.0

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -135,20 +135,20 @@ samsung 22
 # snapshot of `npx browserslist "maintained node versions"`
 # On update check all #stable-snapshot markers
 [node]
-node 12.0
+node 14.0
 
 # same as `node`
 [coverage]
-node 12.0
+node 14.0
 
 # same as `node`
 [development]
-node 12.0
+node 14.0
 
 # same as `node`
 [test]
-node 12.0
+node 14.0
 
 # same as `node`
 [benchmark]
-node 12.0
+node 14.0

--- a/packages/pigment-css-nextjs-plugin/package.json
+++ b/packages/pigment-css-nextjs-plugin/package.json
@@ -49,5 +49,8 @@
     "zero-virtual.css",
     "package.json",
     "LICENSE"
-  ]
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/pigment-css-react/package.json
+++ b/packages/pigment-css-react/package.json
@@ -200,6 +200,9 @@
       "default": "./build/Grid.js"
     }
   },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "nx": {
     "targets": {
       "test": {

--- a/packages/pigment-css-unplugin/package.json
+++ b/packages/pigment-css-unplugin/package.json
@@ -52,5 +52,8 @@
     "build",
     "package.json",
     "LICENSE"
-  ]
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }

--- a/packages/pigment-css-vite-plugin/package.json
+++ b/packages/pigment-css-vite-plugin/package.json
@@ -50,5 +50,8 @@
     "build",
     "package.json",
     "LICENSE"
-  ]
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  }
 }


### PR DESCRIPTION
Same minimum version increase as in https://github.com/mui/material-ui/pull/42920, from v12.0.0 to v14.0.0. No reason for the version to be different.