### PR TITLE
[docs] Fix syntax in JSDoc example

### DIFF
--- a/packages/pigment-css-react/src/utils/extendTheme.ts
+++ b/packages/pigment-css-react/src/utils/extendTheme.ts
@@ -30,7 +30,7 @@ export interface ThemeInput<ColorScheme extends string = string> extends Record<
    *
    * @example
    * // data-* attribute selector
-   * (colorScheme) => colorScheme !== 'light' ? `[data-theme="${colorScheme}"`] : ":root"
+   * (colorScheme) => colorScheme !== 'light' ? `[data-theme="${colorScheme}"]` : ":root"
    */
   getSelector?: (
     colorScheme: ColorScheme | undefined,


### PR DESCRIPTION
Fix semantics for the jsdoc provided for getSelector