### PR TITLE
[nextjs] fix hard crash of nextjs

### DIFF
--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -356,10 +356,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
           code: result.code,
           map: result.sourceMap,
         };
-      } catch (e) {
-        const error = new Error((e as Error).message);
-        error.stack = (e as Error).stack;
-        throw error;
+      } catch(e) {
       }
     },
   };


### PR DESCRIPTION
This pr aims to fix this issue https://github.com/mui/pigment-css/issues/268

In webpack I don't really see the need for throwing a new error. This throw will crash webpack. By just removing the throw we do get the Webpack Error in the browser.

Wrapping `this.handleCall(this.callParam, values);` in a try catch also fixes the crash of using the theme object in wrong way. However I do not really get how this error should be displayed in the webpack error view. Need some help there