### PR TITLE
[examples] Fix webpack CLI instructions

### DIFF
--- a/examples/pigment-css-nextjs-ts/package.json
+++ b/examples/pigment-css-nextjs-ts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "pigment-css-nextjs-ts",
-  "version": "5.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/pigment-css-remix-ts/package.json
+++ b/examples/pigment-css-remix-ts/package.json
@@ -1,7 +1,6 @@
 {
   "name": "pigment-css-remix-ts",
   "private": true,
-  "sideEffects": false,
   "type": "module",
   "scripts": {
     "build": "remix vite:build",

--- a/examples/pigment-css-vite-ts/package.json
+++ b/examples/pigment-css-vite-ts/package.json
@@ -1,7 +1,6 @@
 {
   "name": "pigment-css-vite-ts",
   "private": true,
-  "version": "5.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/pigment-css-webpack-ts/README.md
+++ b/examples/pigment-css-webpack-ts/README.md
@@ -1,4 +1,4 @@
-# Pigment CSS - Vite with TypeScript example project
+# Pigment CSS - webpack with TypeScript example project
 
 ## How to use
 
@@ -7,8 +7,8 @@ Download the example [or clone the repo](https://github.com/mui/pigment-css):
 <!-- #default-branch-switch -->
 
 ```bash
-curl https://codeload.github.com/mui/pigment-css/tar.gz/master | tar -xz --strip=2 pigment-css-master/examples/pigment-css-vite-ts
-cd pigment-css-vite-ts
+curl https://codeload.github.com/mui/pigment-css/tar.gz/master | tar -xz --strip=2 pigment-css-master/examples/pigment-css-webpack-ts
+cd pigment-css-webpack-ts
 ```
 
 Install it and run:
@@ -22,13 +22,13 @@ or:
 
 <!-- #default-branch-switch -->
 
-[![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/pigment-css/tree/master/examples/pigment-css-vite-ts)
+[![Edit on StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mui/pigment-css/tree/master/examples/pigment-css-webpack-ts)
 
-[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/mui/pigment-css/tree/master/examples/pigment-css-vite-ts)
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/mui/pigment-css/tree/master/examples/pigment-css-webpack-ts)
 
 ## Learn more
 
 To learn more about this example:
 
 - [Pigment CSS documentation](https://github.com/mui/pigment-css/blob/master/README.md) - learn more about Pigment CSS features and APIs.
-- [Vite documentation](https://vite.dev/guide/) - learn about Vite features and APIs.
+- [webpack documentation](https://webpack.js.org/) - learn about webpack features and APIs.

--- a/examples/pigment-css-webpack-ts/package.json
+++ b/examples/pigment-css-webpack-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@app/wp-app",
+  "name": "pigment-css-webpack-ts",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
I noticed this from https://github.com/mui/material-ui/pull/44074. I did a quick check to make sure this wasn't a pattern through our codebase, I found this one too. It's a follow-up on #174.

---

**Off topic**. The Vite example doesn't work (tested with pnpm and npm), it crashes with an ESM issue with prop-types.