### PR TITLE
[react] Fix scoping issue with sx dynamic value transform

### DIFF
--- a/packages/pigment-css-react/src/processors/sx.ts
+++ b/packages/pigment-css-react/src/processors/sx.ts
@@ -99,6 +99,19 @@ export class SxProcessor extends BaseProcessor {
         ([variableId, expression, isUnitLess]) => {
           switch (expression.type) {
             case 'ArrowFunctionExpression': {
+              const fnBody = expression.body as Expression;
+              // try to deserialize AST if possible
+              if (
+                fnBody.type === 'StringLiteral' &&
+                (fnBody.value[0] === '{' || fnBody.value[0] === '[')
+              ) {
+                try {
+                  const body = JSON.parse(fnBody.value);
+                  return t.objectProperty(t.stringLiteral(variableId), body);
+                } catch (ex) {
+                  // proceed as usual
+                }
+              }
               return t.objectProperty(
                 t.stringLiteral(variableId),
                 t.arrayExpression([expression.body as Expression, t.booleanLiteral(isUnitLess)]),

--- a/packages/pigment-css-react/src/processors/sx.ts
+++ b/packages/pigment-css-react/src/processors/sx.ts
@@ -101,10 +101,7 @@ export class SxProcessor extends BaseProcessor {
             case 'ArrowFunctionExpression': {
               const fnBody = expression.body as Expression;
               // try to deserialize AST if possible
-              if (
-                fnBody.type === 'StringLiteral' &&
-                (fnBody.value[0] === '{' || fnBody.value[0] === '[')
-              ) {
+              if (fnBody.type === 'StringLiteral') {
                 try {
                   const body = JSON.parse(fnBody.value);
                   return t.objectProperty(t.stringLiteral(variableId), body);

--- a/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
+++ b/packages/pigment-css-react/src/utils/cssFnValueToVariable.ts
@@ -100,7 +100,6 @@ function parseAndWrapExpression(
 }
 
 function transformThemeKeysInFn(
-  styleKey: string,
   functionString: string,
   options: PluginCustomOptions,
   filename?: string,
@@ -182,7 +181,6 @@ function iterateAndReplaceFunctions(
     try {
       const fnString = value.toString();
       const expression = transformThemeKeysInFn(
-        key,
         fnString,
         options,
         filename,

--- a/packages/pigment-css-react/src/utils/sxObjectExtractor.ts
+++ b/packages/pigment-css-react/src/utils/sxObjectExtractor.ts
@@ -1,5 +1,11 @@
 import type { NodePath } from '@babel/core';
-import { arrowFunctionExpression, cloneNode } from '@babel/types';
+import {
+  arrayExpression,
+  arrowFunctionExpression,
+  booleanLiteral,
+  cloneNode,
+  stringLiteral,
+} from '@babel/types';
 import type {
   ArrowFunctionExpression,
   Expression,
@@ -9,6 +15,7 @@ import type {
 } from '@babel/types';
 import { findIdentifiers } from '@wyw-in-js/transform';
 import { isStaticObjectOrArrayExpression } from './checkStaticObjectOrArray';
+import { isUnitLess } from './isUnitLess';
 
 function validateObjectKey(
   keyPath: NodePath<PrivateName | Expression>,
@@ -66,7 +73,8 @@ function traverseObjectExpression(
   const properties = nodePath.get('properties');
   properties.forEach((property) => {
     if (property.isObjectProperty()) {
-      validateObjectKey(property.get('key'), parentCall);
+      const key = property.get('key');
+      validateObjectKey(key, parentCall);
 
       const value = property.get('value');
       if (!value.isExpression()) {
@@ -93,10 +101,17 @@ function traverseObjectExpression(
           localIdentifiers.push(id);
         });
         if (localIdentifiers.length) {
-          const arrowFn = arrowFunctionExpression(
-            localIdentifiers.map((i) => i.node),
-            cloneNode(value.node),
-          );
+          // eslint-disable-next-line no-nested-ternary
+          const cssKey = key.isIdentifier()
+            ? key.node.name
+            : key.isStringLiteral()
+              ? key.node.value
+              : '';
+          const unitLess = isUnitLess(cssKey);
+          const fnBody = arrayExpression([cloneNode(value.node), booleanLiteral(unitLess)]);
+          // Serialize the actual AST as a string
+          // which then gets deserialized in sx.ts
+          const arrowFn = arrowFunctionExpression([], stringLiteral(JSON.stringify(fnBody)));
           value.replaceWith(arrowFn);
         }
       }

--- a/packages/pigment-css-react/src/utils/sxObjectExtractor.ts
+++ b/packages/pigment-css-react/src/utils/sxObjectExtractor.ts
@@ -101,12 +101,12 @@ function traverseObjectExpression(
           localIdentifiers.push(id);
         });
         if (localIdentifiers.length) {
-          // eslint-disable-next-line no-nested-ternary
-          const cssKey = key.isIdentifier()
-            ? key.node.name
-            : key.isStringLiteral()
-              ? key.node.value
-              : '';
+          let cssKey = '';
+          if (key.isIdentifier()) {
+            cssKey = key.node.name;
+          } else if (key.isStringLiteral()) {
+            cssKey = key.node.value;
+          }
           const unitLess = isUnitLess(cssKey);
           const fnBody = arrayExpression([cloneNode(value.node), booleanLiteral(unitLess)]);
           // Serialize the actual AST as a string


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

For this sample component -

```js
function App(props) {
  return (
    <SliderRail
      {...props}
      sx={[
        props.variant === 'secondary'
          ? { color: props.isRed ? 'red' : 'blue' }
          : { backgroundColor: 'blue', color: 'white' },
      ]}
    />
  );
}
```

In the current sx transform, we were transforming the dynamic part to an arrow function with the same arguments that it was using internally and then later in the `sx.ts` based wyw transform, we were just replacing the arrow function with just its body (to be same as user code). This was being done to play well with wyw were it throws an error if it tries to evaluate an object that references local variables.

Current transform -

```js
sx={[
  props.variant === 'secondary'
    ? { color: (props) => props.isRed ? 'red' : 'blue' }
    : { backgroundColor: 'blue', color: 'white' },
]}
```

This did not play well with minifiers where the variables in transformed function would be renamed like -

```js
 (_props) => _props.isRed ? 'red' : 'blue'
```

So later when we were trying to revert back to user code, it'll just be

```js
{ color: _props.isRed ? 'red' : 'blue' }
```

resulting in an issue trying to use a variable that does not exist. This was more apparent when using webpack with it's terser based uglifier.

This PR fixes the issue by serializing the AST as a string and later on deserializing it and generating the code from the AST.

Partially fixes [#43597](https://github.com/mui/material-ui/issues/43597)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
