### PR TITLE
[docs] Remove next tag from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ cd pigment-css-vite-ts
 #### Manual installation
 
 ```bash
-npm install @pigment-css/react@next
-npm install --save-dev @pigment-css/vite-plugin@next
+npm install @pigment-css/react
+npm install --save-dev @pigment-css/vite-plugin
 ```
 
 Then, in your Vite config file, import the plugin and pass it to the `plugins` array as shown:


### PR DESCRIPTION
This updates the installation instructions for Vite to avoid `npm error code ETARGET`.

Fixes #284.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
