### PR TITLE
[example] Update vite example

### DIFF
--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'import/order': 'off',
     // create-vite generates .jsx
     'react/jsx-filename-extension': 'off',
+    'react/react-in-jsx-scope': 'off',
   },
   overrides: [
     {

--- a/examples/pigment-css-vite-ts/eslint.config.js
+++ b/examples/pigment-css-vite-ts/eslint.config.js
@@ -1,0 +1,25 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  { ignores: ['dist'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+);

--- a/examples/pigment-css-vite-ts/index.html
+++ b/examples/pigment-css-vite-ts/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="initial-scale=1, width=device-width" />
-    <title>Pigment CSS + Vite + TypeScript</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/pigment-css-vite-ts/package.json
+++ b/examples/pigment-css-vite-ts/package.json
@@ -4,20 +4,28 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "dependencies": {
     "@pigment-css/react": "latest",
+    "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest"
   },
   "devDependencies": {
+    "@eslint/js": "latest",
     "@pigment-css/vite-plugin": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",
-    "@vitejs/plugin-react": "latest",
+    "@vitejs/plugin-react-swc": "latest",
+    "eslint": "latest",
+    "eslint-plugin-react-hooks": "latest",
+    "eslint-plugin-react-refresh": "latest",
+    "globals": "latest",
     "typescript": "latest",
+    "typescript-eslint": "latest",
     "vite": "latest"
   }
 }

--- a/examples/pigment-css-vite-ts/src/App.tsx
+++ b/examples/pigment-css-vite-ts/src/App.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { styled, css, keyframes } from '@pigment-css/react';
 
 const scale = keyframes({

--- a/examples/pigment-css-vite-ts/tsconfig.app.json
+++ b/examples/pigment-css-vite-ts/tsconfig.app.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
-    "lib": ["ES2023"],
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -12,6 +13,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "jsx": "react-jsx",
 
     /* Linting */
     "strict": true,
@@ -20,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["src"]
 }

--- a/examples/pigment-css-vite-ts/tsconfig.json
+++ b/examples/pigment-css-vite-ts/tsconfig.json
@@ -1,21 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }

--- a/examples/pigment-css-vite-ts/vite.config.ts
+++ b/examples/pigment-css-vite-ts/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import react from '@vitejs/plugin-react-swc';
 import { pigment, extendTheme } from '@pigment-css/vite-plugin';
 
 // To learn more about theming, visit https://github.com/mui/pigment-css/blob/master/README.md#theming
@@ -32,4 +32,7 @@ export default defineConfig({
     }),
     react(),
   ],
+  optimizeDeps: {
+    include: ['react-is', 'prop-types'],
+  },
 });


### PR DESCRIPTION
This updates the template to the latest Vite starter. It also fixes an issue with Pigment initialization in dev mode by explicitly installing `prop-types` and `react-is` and adding it to the `optimizeDeps`' `include` list. This won't be an issue when we don't use `prop-types` in the stable v1 release.

Fixes https://github.com/mui/pigment-css/issues/291

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
