### PR TITLE
[core] Fix Tidelift reference

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -4,5 +4,5 @@ github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, u
 patreon: # Replace with a single Patreon username
 open_collective: mui-org
 ko_fi: # Replace with a single Ko-fi username
-tidelift: npm/@mui/material
+tidelift: npm/@pigment-css/react
 custom: # Replace with a single custom sponsorship URL


### PR DESCRIPTION
That was weird:

https://github.com/user-attachments/assets/df51b4ac-2e9d-41c0-859f-7ab91db38c46

https://github.com/mui/pigment-css