### PR TITLE
[react] Fix `useTheme` return type

### DIFF
--- a/packages/pigment-css-react/src/useTheme.d.ts
+++ b/packages/pigment-css-react/src/useTheme.d.ts
@@ -1,3 +1,3 @@
 import { ThemeArgs } from './theme';
 
-export default function useTheme(): ThemeArgs extends { theme: any } ? ThemeArgs['theme'] : any;
+export default function useTheme(): ThemeArgs extends { theme: unknown } ? ThemeArgs['theme'] : any;


### PR DESCRIPTION
Fixes https://github.com/mui/material-ui/issues/44381.

Check the TS playground for more details: https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgCoAsIFsIEEoDmAzsgN7IBQyyYmOAXGcjAPYuMDkARnFBwL4VBFAPQjkAVyKgCyOCACeyYCRAswyAO4soAaxlySEAB4AHCAkgATCjAkhLwFiElEIGbBAAyEAogUAFACUjB44+MTIJpAgViTktJ6M8kr8yAD8aHR4hEQA2hyJOBwAusjJikxQEGASUC4gEgA2TcjCCM5EGk2+-mEoALyu7tk+fgiBQQDcFKLiUgb2umqaLtp6JHBGZhbWtvaOzsP9waHZEdsxcUxFEIxLKy5pmf0XBbel5XKV5NW19UxWOxkNxeAI2rMOiAujRssghlIRp5gjMgA