### PR TITLE
fix: use the correct serializer based on the direction value

### DIFF
--- a/packages/pigment-css-react/package.json
+++ b/packages/pigment-css-react/package.json
@@ -73,7 +73,7 @@
     "react": "^18.3.1"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/pigment-css-react/tests/utils/preprocessor.test.ts
+++ b/packages/pigment-css-react/tests/utils/preprocessor.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { preprocessor } from '@pigment-css/react/utils';
+
+describe('preprocessor', () => {
+  it('should preprocess selector and css by default to ltr', () => {
+    const res = preprocessor('.hello', 'padding-left: 10px; transform: translate(10px, 20px)');
+    expect(res).to.equal('.hello{padding-left:10px;transform:translate(10px, 20px);}');
+  });
+
+  it('should preprocess selector and css to rtl when specified', () => {
+    const res = preprocessor('.hello', 'padding-left: 10px; transform: translate(10px, 20px)', {
+      defaultDirection: 'rtl',
+      generateForBothDir: false,
+    });
+    expect(res).to.equal('.hello{padding-right:10px;transform:translate(-10px, 20px);}');
+  });
+
+  it('should generate both rtl and ltr css when "generateForBothDir" is true', () => {
+    expect(
+      preprocessor('.hello', 'padding-left: 10px; transform: translate(10px, 20px)', {
+        defaultDirection: 'ltr',
+        generateForBothDir: true,
+      }),
+    ).to.equal(
+      '.hello{padding-left:10px;transform:translate(10px, 20px);}[dir=rtl] .hello{padding-right:10px;transform:translate(-10px, 20px);}',
+    );
+
+    expect(
+      preprocessor('.hello', 'padding-right: 10px; transform: translate(-10px, 20px)', {
+        defaultDirection: 'rtl',
+        generateForBothDir: true,
+      }),
+    ).to.equal(
+      '.hello{padding-left:10px;transform:translate(10px, 20px);}[dir=ltr] .hello{padding-right:10px;transform:translate(-10px, 20px);}',
+    );
+  });
+});

--- a/packages/pigment-css-unplugin/src/index.ts
+++ b/packages/pigment-css-unplugin/src/index.ts
@@ -115,7 +115,7 @@ export const plugin = createUnplugin<PigmentOptions, true>((options) => {
     theme,
     meta,
     transformLibraries = [],
-    preprocessor = basePreprocessor,
+    preprocessor,
     asyncResolve: asyncResolveOpt,
     debug = false,
     sourceMap = false,

--- a/packages/pigment-css-vite-plugin/src/vite-plugin.ts
+++ b/packages/pigment-css-vite-plugin/src/vite-plugin.ts
@@ -20,7 +20,11 @@ import {
   type PluginOptions,
   type IFileReporterOptions,
 } from '@wyw-in-js/transform';
-import { matchAdapterPath, type PluginCustomOptions } from '@pigment-css/react/utils';
+import {
+  matchAdapterPath,
+  type PluginCustomOptions,
+  preprocessor as basePreprocessor,
+} from '@pigment-css/react/utils';
 import { styledEngineMockup } from '@pigment-css/react/internal';
 
 export type VitePluginOptions = {
@@ -73,6 +77,10 @@ export default function wywVitePlugin({
   let devServer: ViteDevServer;
 
   const { emitter, onDone } = createFileReporter(debug ?? false);
+
+  const withRtl = (selector: string, cssText: string) => {
+    return basePreprocessor(selector, cssText, cssConfig);
+  };
 
   // <dependency id, targets>
   const targets: { dependencies: string[]; id: string }[] = [];
@@ -198,7 +206,7 @@ export default function wywVitePlugin({
             options: {
               filename: id,
               root: process.cwd(),
-              preprocessor,
+              preprocessor: preprocessor ?? withRtl,
               pluginOptions: {
                 ...other,
                 features: {


### PR DESCRIPTION
Curently, the assumption was that the rtl css would only be needed as an addon.
Fixed this to always use an explicit direction serializer based on the direction.
Also, the Vite plugin was not passing on the direction information to pre-processor. This has been fixed.

Fixes https://github.com/mui/material-ui/issues/44647

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Tested on user's repo with a local build of Pigment.

<img width="1916" alt="Screenshot 2024-12-17 at 5 32 20 PM" src="https://github.com/user-attachments/assets/269f5650-0f6a-4b81-a8f6-ddad53c63310" />

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
