### PR TITLE
fix: type CreateStyledComponent to accept string and object

### DIFF
--- a/packages/pigment-css-react/src/styled.d.ts
+++ b/packages/pigment-css-react/src/styled.d.ts
@@ -33,9 +33,10 @@ export interface CreateStyledComponent<
   Component extends React.ElementType,
   OuterProps extends object,
 > {
+  // Template Literal case
   (
     styles: TemplateStringsArray,
-    ...args: Array<((options: ThemeArgs) => Primitve) | Primitve | React.ComponentClass>
+    ...args: Array<((options: ThemeArgs) => Primitve)| Primitve | React.ComponentClass | StyledArgument<OuterProps>>
   ): StyledComponent<OuterProps> & (Component extends string ? BaseDefaultProps : Component);
 
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

fixes #188 

The code below now does not show type errors.

```ts
const Colors = {
  text: '#000',
  highlight: '#25f'
}
const typo_body = {
  fontSize: 14,
  fontWeight: 500
}

const ButtonWithMixedInterpolation = styled.button`
  ${typo_body};
  color: ${Colors.highlight};
`;
```