### PR TITLE
fix: spread style object before deleting variants

### DIFF
--- a/packages/pigment-css-react/src/processors/styled.ts
+++ b/packages/pigment-css-react/src/processors/styled.ts
@@ -611,6 +611,7 @@ export class StyledProcessor extends BaseProcessor {
     if (!styleObj) {
       return '';
     }
+    styleObj = { ...styleObj };
     if (styleObj.variants) {
       variantsAccumulator?.push(
         ...styleObj.variants.map((variant: Omit<VariantData, 'originalExpression'>) => ({


### PR DESCRIPTION
This was mutating the original theme object resulting in different codes for server and client components.

Fixes: https://github.com/mui/material-ui/issues/44675

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
