### PR TITLE
Allow `false` in the sx TypeScript types

### DIFF
--- a/packages/pigment-css-react/src/sx.d.ts
+++ b/packages/pigment-css-react/src/sx.d.ts
@@ -6,6 +6,6 @@ type GetTheme<Argument> = Argument extends { theme: infer Theme } ? Theme : neve
 export type SxProp =
   | CSSObjectNoCallback
   | ((theme: GetTheme<ThemeArgs>) => CSSObjectNoCallback)
-  | ReadonlyArray<CSSObjectNoCallback | ((theme: GetTheme<ThemeArgs>) => CSSObjectNoCallback)>;
+  | ReadonlyArray<CSSObjectNoCallback | ((theme: GetTheme<ThemeArgs>) => CSSObjectNoCallback) | false>;
 
 export default function sx(arg: SxProp, componentClass?: string): string;

--- a/packages/pigment-css-react/tests/sx.spec.ts
+++ b/packages/pigment-css-react/tests/sx.spec.ts
@@ -11,6 +11,7 @@ const sx3: SxProp = [{ color: 'red' }, { backgroundColor: 'blue', color: 'white'
 const test = true;
 const sx4: SxProp = [
   test ? { color: 'red' } : { backgroundColor: 'blue', color: 'white' },
+  false,
   (theme) => ({
     border: `1px solid ${theme.palette.primary.main}`,
   }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The following snippet is from the documentation:

```
<div
  sx={[
    { color: 'red' },
    selected && { fontWeight: 'bold' },
    disabled ? (theme) => ({ opacity: theme.state.disabledOpacity }) : { opacity: 1 },
  ]}
/>
```

However, this generates a TypeScript error that `boolean` is not allowed in the sx prop.

This PR allows for `false` values to be in the SxProp array, like it is allowed in `@mui/system`.