### PR TITLE
Improve documentation about adding TypeScript support for the `sx` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,17 +778,12 @@ The value provided to `sx` prop can be one of the following:
 To use `sx` prop on HTML element, you need to augment the `HTMLAttributes` interface. Add the following code to a file that is included in your tsconfig.json:
 
 ```ts
-type Theme = {
-  // your theme type
-};
+import { SxProp } from '@pigment-css/react';
 
 declare global {
   namespace React {
     interface HTMLAttributes<T> {
-      sx?:
-        | React.CSSProperties
-        | ((theme: Theme) => React.CSSProperties)
-        | ReadonlyArray<React.CSSProperties | ((theme: Theme) => React.CSSProperties)>;
+      sx?: SxProp;
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

This clarifies in the `README.md` that you can import `SxProp` from `@pigment-css/react` to add `sx` support to all HTML elements.