### PR TITLE
Add Turbopack loader support and automatically adapt to Webpack

### DIFF
--- a/examples/pigment-css-nextjs-ts/tsconfig.json
+++ b/examples/pigment-css-nextjs-ts/tsconfig.json
@@ -9,10 +9,10 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -21,9 +21,17 @@
     ],
     "baseUrl": ".",
     "paths": {
+      "react": ["./node_modules/@types/react"],
+      "react-dom": ["./node_modules/@types/react-dom"],
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/packages/pigment-css-nextjs-plugin/package.json
+++ b/packages/pigment-css-nextjs-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@pigment-css/nextjs-plugin",
   "version": "0.0.31",
   "author": "MUI Team",
-  "description": "Next.js integration for Pigment CSS.",
+  "description": "Next.js integration for Pigment CSS.",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.mjs",
@@ -28,7 +28,11 @@
     "typescript": "tsc --noEmit -p ."
   },
   "dependencies": {
-    "@pigment-css/unplugin": "workspace:^"
+    "@babel/preset-react": "^7.25.9",
+    "@babel/preset-typescript": "^7.26.0",
+    "@pigment-css/unplugin": "workspace:^",
+    "@wyw-in-js/shared": "^1.1.0",
+    "@wyw-in-js/transform": "^1.1.0"
   },
   "devDependencies": {
     "next": "^15.1.3",

--- a/packages/pigment-css-nextjs-plugin/src/index.ts
+++ b/packages/pigment-css-nextjs-plugin/src/index.ts
@@ -1,7 +1,10 @@
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import type { NextConfig } from 'next';
 import { findPagesDir } from 'next/dist/lib/find-pages-dir';
 import { webpack as webpackPlugin, extendTheme, type PigmentOptions } from '@pigment-css/unplugin';
+import { slugify } from '@wyw-in-js/shared';
+import { generateTokenCss } from '@pigment-css/react/utils';
 
 export { type PigmentOptions };
 
@@ -10,15 +13,133 @@ const extractionFile = path.join(
   'zero-virtual.css',
 );
 
+function scanDirectory(dir: string, fileList: string[] = []): string[] {
+  const dirName = path.basename(dir);
+  if (
+    dirName === 'node_modules' ||
+    dirName === '.next' ||
+    dirName === '.git' ||
+    dir === path.resolve(__dirname, '..', 'virtual')
+  ) {
+    return fileList;
+  }
+  try {
+    const files = fs.readdirSync(dir, { withFileTypes: true });
+    files.forEach((file) => {
+      const fullPath = path.join(dir, file.name);
+      if (file.isDirectory()) {
+        scanDirectory(fullPath, fileList);
+      } else if (file.isFile() && /\.(tsx|ts|jsx|js)$/.test(file.name)) {
+        fileList.push(fullPath);
+      }
+    });
+  } catch {
+    // Ignore
+  }
+  return fileList;
+}
+
 export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptions) {
   const { babelOptions = {}, asyncResolve, ...other } = pigmentConfig ?? {};
-  if (process.env.TURBOPACK === '1') {
-    // eslint-disable-next-line no-console
-    console.log(
-      `\x1B[33m${process.env.PACKAGE_NAME}: Turbo mode is not supported yet. Please disable it by removing the "--turbo" flag from your "next dev" command to use Pigment CSS.\x1B[39m`,
-    );
-    return nextConfig;
+
+  // === Turbopack configuration (always prepared) ===
+  const virtualDir = path.resolve(__dirname, '../virtual');
+
+  if (!fs.existsSync(virtualDir)) {
+    fs.mkdirSync(virtualDir, { recursive: true });
   }
+  // Pre-create virtual CSS files for all source files to bypass Turbopack's startup resolver cache
+  const sourceFiles = scanDirectory(process.cwd());
+  const activeSlugs = new Set<string>();
+
+  sourceFiles.forEach((file) => {
+    const slug = slugify(file);
+    const cssFileName = `${slug}.css`;
+    activeSlugs.add(cssFileName);
+    const cssPath = path.join(virtualDir, cssFileName);
+    if (!fs.existsSync(cssPath)) {
+      fs.writeFileSync(cssPath, '', 'utf8');
+    }
+  });
+  try {
+    const files = fs.readdirSync(virtualDir);
+    files.forEach((file) => {
+      if (file.endsWith('.css') && !activeSlugs.has(file)) {
+        fs.rmSync(path.join(virtualDir, file), { force: true });
+      }
+    });
+  } catch {
+    // Ignore
+  }
+  const cacheDir = path.resolve(process.cwd(), '.next/cache');
+  if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir, { recursive: true });
+  }
+  const themeCachePath = path.join(cacheDir, 'pigment-theme.json');
+  const serializedTheme = JSON.stringify(other.theme ?? {}, (_key, value) => {
+    if (typeof value === 'function') {
+      return undefined;
+    }
+    return value;
+  });
+  fs.writeFileSync(themeCachePath, serializedTheme, 'utf8');
+
+  // Pre-generate token CSS while the full theme (with functions) is still available.
+  // JSON serialization strips generateStyleSheets, so generateTokenCss would return empty in the loader.
+  const tokenCssCachePath = path.join(cacheDir, 'pigment-token.css');
+  const tokenCss = generateTokenCss(other.theme);
+  fs.writeFileSync(tokenCssCachePath, tokenCss, 'utf8');
+
+  const turbopackLoaderItem = {
+    loader: require.resolve('./turbopack-loader'),
+    options: {
+      themeCachePath,
+      tokenCssCachePath,
+      transformLibraries: other.transformLibraries ?? [],
+      babelOptions: babelOptions ?? {},
+      css: other.css ?? null,
+    },
+  };
+
+  const turbopackNewRules = {
+    '*.ts': { loaders: [turbopackLoaderItem] },
+    '*.tsx': { loaders: [turbopackLoaderItem] },
+    '*.js': { loaders: [turbopackLoaderItem] },
+    '*.jsx': { loaders: [turbopackLoaderItem] },
+    '*.css': { loaders: [turbopackLoaderItem] },
+  };
+
+  type TurbopackRule = { loaders: Array<Record<string, unknown>> };
+  type TurbopackRules = Record<string, TurbopackRule>;
+
+  const mergeTurbopackRules = (
+    rulesToMerge: TurbopackRules,
+    existingRules: TurbopackRules = {},
+  ): TurbopackRules => {
+    const mergedRules: TurbopackRules = { ...existingRules };
+    Object.entries(rulesToMerge).forEach(([key, rule]) => {
+      const existing = mergedRules[key];
+      if (existing) {
+        mergedRules[key] = {
+          ...existing,
+          loaders: [...rule.loaders, ...existing.loaders],
+        };
+      } else {
+        mergedRules[key] = rule;
+      }
+    });
+    return mergedRules;
+  };
+
+  const nextConfigWithTurbo = nextConfig as NextConfig & {
+    turbopack?: {
+      rules?: TurbopackRules;
+      resolveAlias?: Record<string, string>;
+    };
+  };
+
+  // === Webpack configuration (lazy — only executed when Webpack is actually used) ===
+  const originalWebpack = nextConfig.webpack;
 
   const webpack: Exclude<NextConfig['webpack'], undefined> = (config, context) => {
     const { dir, dev, isServer, config: resolvedNextConfig } = context;
@@ -94,8 +215,8 @@ export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptio
       }),
     );
 
-    if (typeof nextConfig.webpack === 'function') {
-      return nextConfig.webpack(config, context);
+    if (typeof originalWebpack === 'function') {
+      return originalWebpack(config, context);
     }
     config.ignoreWarnings = config.ignoreWarnings ?? [];
     config.ignoreWarnings.push({
@@ -103,8 +224,18 @@ export function withPigment(nextConfig: NextConfig, pigmentConfig?: PigmentOptio
     });
     return config;
   };
+
+  // === Return both turbopack and webpack configs ===
   return {
-    ...nextConfig,
+    ...nextConfigWithTurbo,
+    turbopack: {
+      ...nextConfigWithTurbo.turbopack,
+      rules: mergeTurbopackRules(turbopackNewRules, nextConfigWithTurbo.turbopack?.rules),
+      resolveAlias: {
+        ...nextConfigWithTurbo.turbopack?.resolveAlias,
+        '@pigment-css/nextjs-plugin/virtual': virtualDir,
+      },
+    },
     webpack,
   };
 }

--- a/packages/pigment-css-nextjs-plugin/src/turbopack-loader.ts
+++ b/packages/pigment-css-nextjs-plugin/src/turbopack-loader.ts
@@ -1,0 +1,243 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { transform, TransformCacheCollection, type Result } from '@wyw-in-js/transform';
+import { slugify } from '@wyw-in-js/shared';
+import {
+  matchAdapterPath,
+  preprocessor as basePreprocessor,
+  generateThemeSource,
+} from '@pigment-css/react/utils';
+import { styledEngineMockup } from '@pigment-css/react/internal';
+
+const cache = new TransformCacheCollection();
+
+const stripQueryAndHash = (request: string): string => {
+  const queryIdx = request.indexOf('?');
+  const hashIdx = request.indexOf('#');
+  if (queryIdx === -1) {
+    return hashIdx === -1 ? request : request.slice(0, hashIdx);
+  }
+  if (hashIdx === -1) {
+    return request.slice(0, queryIdx);
+  }
+  return request.slice(0, Math.min(queryIdx, hashIdx));
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function turbopackLoader(this: any, content: string) {
+  const callback = this.async();
+
+  const {
+    themeCachePath,
+    transformLibraries = [],
+    babelOptions = {},
+    ...other
+  } = this.getOptions() || {};
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let theme: Record<string, any> = {};
+  if (themeCachePath && fs.existsSync(themeCachePath)) {
+    try {
+      const themeJson = fs.readFileSync(themeCachePath, 'utf8');
+      theme = JSON.parse(themeJson);
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  // Hydrate theme helper functions for evaluation sandbox
+  theme.getColorSchemeSelector = (colorScheme: string) => {
+    if (!theme.getSelector) {
+      return `@media (prefers-color-scheme: ${colorScheme})`;
+    }
+    return `:where(${theme.getSelector(colorScheme, {})}) &`;
+  };
+
+  theme.applyStyles = function applyStyles(colorScheme: string, styles: Record<string, unknown>) {
+    return {
+      [this.getColorSchemeSelector(colorScheme)]: styles,
+    };
+  };
+
+  const defaultLibs = ['@pigment-css/react', '@mui/material-pigment-css'];
+  const allLibs = transformLibraries.concat(defaultLibs);
+  const finalTransformLibraries = allLibs.map((lib: string) => lib.split('/').join(path.sep));
+
+  const resourcePath = this.resourcePath;
+
+  const isStylesCss = finalTransformLibraries.some(
+    (lib: string) =>
+      resourcePath.endsWith(`${lib}${path.sep}styles.css`) ||
+      resourcePath.endsWith('/pigment-css-react/styles.css'),
+  );
+
+  const isThemeFile = finalTransformLibraries.some(
+    (lib: string) =>
+      resourcePath.includes(`${lib}${path.sep}theme`) ||
+      resourcePath.includes('/pigment-css-react/theme'),
+  );
+
+  if (isStylesCss) {
+    const { tokenCssCachePath } = this.getOptions() || {};
+    let cssText = '';
+    if (tokenCssCachePath && fs.existsSync(tokenCssCachePath)) {
+      cssText = fs.readFileSync(tokenCssCachePath, 'utf8');
+    }
+    return callback(null, cssText);
+  }
+
+  if (isThemeFile) {
+    const themeSource = generateThemeSource(theme);
+    return callback(null, themeSource);
+  }
+
+  if (resourcePath.endsWith('.css')) {
+    return callback(null, content);
+  }
+
+  const resolveModule = this.getResolve({
+    dependencyType: 'esm',
+  });
+
+  const asyncResolve = async (token: string, importer: string): Promise<string> => {
+    // 1. Resolve mocks and stubs for Next.js/React evaluation
+    if (token.startsWith('__barrel_optimize__')) {
+      return require.resolve('../next-font');
+    }
+    if (token === 'next/image' || token === 'next/link') {
+      return require.resolve('../next-image');
+    }
+    if (token.startsWith('next/font')) {
+      return require.resolve('../next-font');
+    }
+    if (token.startsWith('@emotion/styled') || token.startsWith('styled-components')) {
+      return require.resolve('../third-party-styled');
+    }
+    if (
+      token === 'react' ||
+      token.startsWith('react/') ||
+      token.startsWith('react-dom/') ||
+      token.startsWith('@babel/') ||
+      token.startsWith('next/')
+    ) {
+      return require.resolve(token);
+    }
+
+    // 2. Fallback to standard resolution
+    const context = path.isAbsolute(importer)
+      ? path.dirname(importer)
+      : path.join(process.cwd(), path.dirname(importer));
+
+    const result = await new Promise<string>((resolve, reject) => {
+      resolveModule(context, token, (err: Error | null, res: string) => {
+        if (err) {
+          reject(err);
+        } else if (res) {
+          resolve(res);
+        } else {
+          reject(new Error(`Cannot resolve ${token}`));
+        }
+      });
+    });
+
+    const filePath = stripQueryAndHash(result);
+    if (path.isAbsolute(filePath)) {
+      this.addDependency(filePath);
+    }
+    return result;
+  };
+
+  const plugins = [
+    require.resolve('@pigment-css/react/exports/remove-prop-types-plugin'),
+    'babel-plugin-define-var',
+    ...(babelOptions?.plugins ?? []),
+  ];
+
+  const transformServices = {
+    options: {
+      filename: this.resourcePath,
+      root: process.cwd(),
+      preprocessor: (selector: string, cssText: string) => {
+        return basePreprocessor(selector, cssText, other.css);
+      },
+      pluginOptions: {
+        ...other,
+        themeArgs: {
+          theme,
+        },
+        packageMap: transformLibraries.reduce(
+          (acc: Record<string, string>, lib: string) => {
+            acc[lib] = lib;
+            return acc;
+          },
+          {} as Record<string, string>,
+        ),
+        features: {
+          useWeakRefInEval: false,
+          ...other.features,
+        },
+        overrideContext(context: Record<string, unknown>) {
+          if (!context.$RefreshSig$) {
+            context.$RefreshSig$ = () => () => {};
+          }
+          // Mock styled engine to prevent runtime styled component errors in evaluation
+          const originalRequire = context.require as (id: string) => unknown;
+          context.require = (id: string) => {
+            if (id === '@mui/styled-engine' || id === '@mui/styled-engine-sc') {
+              return styledEngineMockup;
+            }
+            return originalRequire(id);
+          };
+          return context;
+        },
+        tagResolver(source: string, tag: string) {
+          if (matchAdapterPath(source)) {
+            return require.resolve(`@pigment-css/react/exports/${tag}`);
+          }
+          return null;
+        },
+        babelOptions: {
+          ...babelOptions,
+          plugins,
+          presets: [
+            ...(babelOptions?.presets ?? []),
+            require.resolve('@babel/preset-typescript'),
+            [require.resolve('@babel/preset-react'), { runtime: 'automatic' }],
+          ],
+        },
+      },
+    },
+    cache,
+  };
+
+  return transform(transformServices, content, asyncResolve)
+    .then(async (result: Result) => {
+      if (result.cssText) {
+        const slug = slugify(this.resourcePath);
+        const virtualDir = path.resolve(__dirname, '..', 'virtual');
+        if (!fs.existsSync(virtualDir)) {
+          fs.mkdirSync(virtualDir, { recursive: true });
+        }
+        const cssFilePath = path.join(virtualDir, `${slug}.css`);
+
+        let { cssText } = result;
+
+        // Wrap in @layer to maintain CSS ordering between layout.tsx and page.tsx,
+        // matching the webpack unplugin behavior.
+        const cssSlug = slugify(cssText);
+        const layerName = `_${cssSlug}`;
+        cssText = `@layer pigment.${layerName} {\n${cssText}\n}\n`;
+
+        fs.writeFileSync(cssFilePath, cssText, 'utf8');
+
+        // Import the written CSS file relatively via package name to bypass global CSS imports check
+        const finalCode = `${result.code}\nimport "@pigment-css/nextjs-plugin/virtual/${slug}.css";`;
+        callback(null, finalCode, result.sourceMap ?? undefined);
+      } else {
+        callback(null, result.code, result.sourceMap ?? undefined);
+      }
+    })
+    .catch((err: Error) => {
+      callback(err);
+    });
+}

--- a/packages/pigment-css-nextjs-plugin/tsup.config.ts
+++ b/packages/pigment-css-nextjs-plugin/tsup.config.ts
@@ -3,11 +3,21 @@ import config from '../../tsup.config';
 
 const configOptions = config as Options;
 
-const baseConfig: Options = {
-  ...configOptions,
-  tsconfig: './tsconfig.build.json',
-  cjsInterop: true,
-  entry: ['./src/index.ts', './src/virtual-css-loader.js'],
-};
-
-export default defineConfig(baseConfig);
+export default defineConfig([
+  {
+    ...configOptions,
+    tsconfig: './tsconfig.build.json',
+    cjsInterop: true,
+    entry: ['./src/index.ts', './src/virtual-css-loader.js'],
+  },
+  {
+    ...configOptions,
+    tsconfig: './tsconfig.build.json',
+    cjsInterop: false,
+    splitting: false,
+    format: ['cjs'],
+    entry: {
+      'turbopack-loader': './src/turbopack-loader.ts',
+    },
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-webpack:
         specifier: ^0.13.8
-        version: 0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0))
+        version: 0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0))
       eslint-plugin-babel:
         specifier: ^5.3.1
         version: 5.3.1(eslint@8.57.0)
@@ -164,7 +164,7 @@ importers:
         version: 11.2.0
       lerna:
         specifier: ^8.1.2
-        version: 8.1.2(encoding@0.1.13)
+        version: 8.1.2(@swc/core@1.15.40)(encoding@0.1.13)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -176,7 +176,7 @@ importers:
         version: 10.8.2
       nx:
         specifier: ^18.2.3
-        version: 18.2.4
+        version: 18.2.4(@swc/core@1.15.40)
       nyc:
         specifier: ^15.1.0
         version: 15.1.0
@@ -218,7 +218,7 @@ importers:
         version: 36.0.0(stylelint@16.3.1(typescript@5.6.3))
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(jiti@1.21.6)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
+        version: 8.3.5(@swc/core@1.15.40)(jiti@1.21.6)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
       tsx:
         specifier: ^4.19.2
         version: 4.19.2
@@ -343,7 +343,7 @@ importers:
         version: 18.3.1
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.3.3(vite@5.4.10(@types/node@20.17.10)(terser@5.30.3))
+        version: 4.3.3(vite@5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3))
       postcss:
         specifier: ^8.4.47
         version: 8.4.49
@@ -352,10 +352,10 @@ importers:
         version: 1.0.1
       vite:
         specifier: 5.4.10
-        version: 5.4.10(@types/node@20.17.10)(terser@5.30.3)
+        version: 5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3)
       vite-plugin-pages:
         specifier: ^0.32.3
-        version: 0.32.3(react-router@6.27.0(react@18.3.1))(vite@5.4.10(@types/node@20.17.10)(terser@5.30.3))
+        version: 0.32.3(react-router@6.27.0(react@18.3.1))(vite@5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3))
 
   docs:
     dependencies:
@@ -431,7 +431,7 @@ importers:
         version: 18.3.1
       eslint-config-next:
         specifier: 15.0.2
-        version: 15.0.2(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0)(typescript@5.6.3)
+        version: 15.0.2(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
       serve:
         specifier: 14.2.4
         version: 14.2.4
@@ -446,10 +446,10 @@ importers:
         version: 8.56.7
       '@typescript-eslint/experimental-utils':
         specifier: ^5.62.0
-        version: 5.62.0(eslint@8.57.0)(typescript@5.6.3)
+        version: 5.62.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ^7.5.0
-        version: 7.6.0(eslint@8.57.0)(typescript@5.6.3)
+        version: 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
 
   packages/pigment-css-core:
     dependencies:
@@ -470,7 +470,7 @@ importers:
         version: 1.1.0
       '@wyw-in-js/transform':
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.6.3)
+        version: 1.1.0(typescript@6.0.3)
       csstype:
         specifier: ^3.1.3
         version: 3.1.3
@@ -487,9 +487,21 @@ importers:
 
   packages/pigment-css-nextjs-plugin:
     dependencies:
+      '@babel/preset-react':
+        specifier: ^7.25.9
+        version: 7.25.9(@babel/core@7.26.0)
+      '@babel/preset-typescript':
+        specifier: ^7.26.0
+        version: 7.26.0(@babel/core@7.26.0)
       '@pigment-css/unplugin':
         specifier: workspace:^
         version: link:../pigment-css-unplugin
+      '@wyw-in-js/shared':
+        specifier: ^1.1.0
+        version: 1.1.0
+      '@wyw-in-js/transform':
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@6.0.3)
     devDependencies:
       next:
         specifier: ^15.1.3
@@ -547,7 +559,7 @@ importers:
         version: 1.1.0
       '@wyw-in-js/transform':
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.6.3)
+        version: 1.1.0(typescript@6.0.3)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -644,7 +656,7 @@ importers:
         version: 1.1.0
       '@wyw-in-js/transform':
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.6.3)
+        version: 1.1.0(typescript@6.0.3)
       babel-plugin-define-var:
         specifier: ^0.1.0
         version: 0.1.0
@@ -666,7 +678,7 @@ importers:
         version: 4.5.0
       webpack:
         specifier: ^5.91.0
-        version: 5.91.0(esbuild@0.24.0)
+        version: 5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)
 
   packages/pigment-css-utils:
     dependencies:
@@ -693,7 +705,7 @@ importers:
         version: 1.1.0
       '@wyw-in-js/transform':
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.6.3)
+        version: 1.1.0(typescript@6.0.3)
       cssesc:
         specifier: ^3.0.0
         version: 3.0.0
@@ -730,7 +742,7 @@ importers:
         version: 1.1.0
       '@wyw-in-js/transform':
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.6.3)
+        version: 1.1.0(typescript@6.0.3)
       babel-plugin-define-var:
         specifier: ^0.1.0
         version: 0.1.0
@@ -740,7 +752,7 @@ importers:
         version: 7.20.5
       vite:
         specifier: ^6.0.5
-        version: 6.0.5(@types/node@20.17.10)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.2)(yaml@2.6.0)
+        version: 6.0.5(@types/node@25.9.1)(jiti@1.21.6)(lightningcss@1.32.0)(terser@5.30.3)(tsx@4.19.2)(yaml@2.6.0)
 
 packages:
 
@@ -927,6 +939,7 @@ packages:
   '@babel/plugin-proposal-explicit-resource-management@7.25.9':
     resolution: {integrity: sha512-EbtfSvb6s4lZwef1nH52nw4DTUAvHY6bl1mbLgEHUkR6L8j4WY70mM/InB8Ozgdlok/7etbiSW+Wc88ZebZAKQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-explicit-resource-management instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -1903,9 +1916,31 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.10.0':
     resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
@@ -1914,6 +1949,14 @@ packages:
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@floating-ui/core@1.6.0':
     resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
@@ -1953,6 +1996,18 @@ packages:
     resolution: {integrity: sha512-nPgzOiDs/FSFhE+dX2KfkmsmkXM3WfXYP06FoW8cXvHshwxHSI3FbXwe5XJYstDAWXP9YA7AMSvmwnuD4OAl2w==}
     engines: {node: '>=12.0.0'}
 
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -1965,6 +2020,10 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@hutson/parse-repository-url@3.0.2':
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
@@ -2115,6 +2174,7 @@ packages:
   '@lerna/create@8.1.2':
     resolution: {integrity: sha512-GzScCIkAW3tg3+Yn/MKCH9963bzG+zpjGz2NdfYDlYWI7p0f/SH46v1dqpPpYmZ2E/m3JK8HjTNNNL8eIm8/YQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: This package is an implementation detail of Lerna and is no longer published separately.
 
   '@mdx-js/mdx@3.1.0':
     resolution: {integrity: sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw==}
@@ -2122,6 +2182,7 @@ packages:
   '@mui/base@5.0.0-beta.61':
     resolution: {integrity: sha512-YaMOTXS3ecDNGsPKa6UdlJ8loFLvcL9+VbpCK3hfk71OaNauZRp4Yf7KeXDYr7Ms3M/XBD3SaiR6JMr6vYtfDg==}
     engines: {node: '>=14.0.0'}
+    deprecated: This package has been replaced by @base-ui/react
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
@@ -2872,6 +2933,9 @@ packages:
 
   '@sinonjs/text-encoding@0.7.3':
     resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
+    deprecated: |-
+      Deprecated: no longer maintained and no longer used by Sinon packages. See
+        https://github.com/sinonjs/nise/issues/243 for replacement details.
 
   '@slack/bolt@4.1.0':
     resolution: {integrity: sha512-7XlTziPVLQn8RXNuOTzsJh/wrkX4YUZr1UpX25MpfDdMpp28Y4TrtIvYDh6GV90uNscdHJhOJcpqLq6ibqfGfg==}
@@ -2901,6 +2965,87 @@ packages:
     resolution: {integrity: sha512-/4UjstX8ploZklY8MmlOQoXB1jWIo3Go4MP0R39sbkoWuN6rJ7Zt6l4bjkDPM4hKsjoODh9SSKn2otlp3XL3/A==}
     engines: {node: '>=14.17'}
 
+  '@swc/core-darwin-arm64@1.15.40':
+    resolution: {integrity: sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.40':
+    resolution: {integrity: sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.40':
+    resolution: {integrity: sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.40':
+    resolution: {integrity: sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.15.40':
+    resolution: {integrity: sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.15.40':
+    resolution: {integrity: sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.15.40':
+    resolution: {integrity: sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.15.40':
+    resolution: {integrity: sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.15.40':
+    resolution: {integrity: sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.15.40':
+    resolution: {integrity: sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.40':
+    resolution: {integrity: sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.40':
+    resolution: {integrity: sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.40':
+    resolution: {integrity: sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -2909,6 +3054,9 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -3007,11 +3155,17 @@ packages:
   '@types/eslint@8.56.7':
     resolution: {integrity: sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/express-serve-static-core@4.19.0':
     resolution: {integrity: sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==}
@@ -3084,6 +3238,9 @@ packages:
 
   '@types/node@20.17.10':
     resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3249,6 +3406,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.3.3':
     resolution: {integrity: sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==}
@@ -3365,6 +3523,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
@@ -3395,6 +3558,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
@@ -3632,6 +3798,10 @@ packages:
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3670,6 +3840,10 @@ packages:
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -4136,6 +4310,10 @@ packages:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   css-functions-list@3.2.1:
     resolution: {integrity: sha512-Nj5YcaGgBtuUmn1D7oHqPW0c9iui7xsTsj5lIX8ZgevdfhmjFfKB3r8moHJtNJnctnYXJyYX5I1pp90HM4TPgQ==}
     engines: {node: '>=12 || >=16'}
@@ -4240,6 +4418,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
     engines: {node: '>=0.10.0'}
@@ -4335,6 +4522,10 @@ packages:
 
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   devlop@1.1.0:
@@ -4710,6 +4901,10 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint-utils@3.0.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -4724,11 +4919,29 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.4.1:
+    resolution: {integrity: sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -4745,6 +4958,10 @@ packages:
 
   esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
+    engines: {node: '>=0.10'}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -5130,6 +5347,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -5139,6 +5357,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -5167,25 +5386,28 @@ packages:
   glob@10.3.12:
     resolution: {integrity: sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -6001,6 +6223,76 @@ packages:
     resolution: {integrity: sha512-fHUxw5VJhZCNSls0KLNEG0mCD2PN1i14gH5elGOgiVnU3VgTcRahagYP2LKI1m0tFCJ+XrAm0zVYyF5RCbXzcg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -6518,6 +6810,10 @@ packages:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.0.5:
     resolution: {integrity: sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==}
 
@@ -6674,6 +6970,7 @@ packages:
   next@15.0.2:
     resolution: {integrity: sha512-rxIWHcAu4gGSDmwsELXacqAPUk+j8dV/A9cDF5fsiCMpkBDYkO2AEaL1dfD+nNmDiU6QMCFN8Q30VEKapT9UHQ==}
     engines: {node: '>=18.18.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -6695,6 +6992,7 @@ packages:
   next@15.1.3:
     resolution: {integrity: sha512-5igmb8N8AEhWDYzogcJvtcRDU6n4cMGtBklxKD4biYv4LXN8+awc/bbQ2IM2NQHdVPgJ6XumYXfo3hBtErg1DA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -6934,6 +7232,7 @@ packages:
 
   oniguruma-to-js@0.4.3:
     resolution: {integrity: sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==}
+    deprecated: use oniguruma-to-es instead
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -8036,6 +8335,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -8281,6 +8581,7 @@ packages:
   tar@6.1.11:
     resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
     engines: {node: '>= 10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -8534,6 +8835,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
@@ -8553,6 +8859,9 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -8697,10 +9006,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.2.0:
@@ -8876,6 +9187,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -10290,12 +10602,40 @@ snapshots:
   '@esbuild/win32-x64@0.24.0':
     optional: true
 
+  '@eslint-community/eslint-utils@4.4.0(eslint@10.4.1(jiti@1.21.6))':
+    dependencies:
+      eslint: 10.4.1(jiti@1.21.6)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
     dependencies:
       eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@1.21.6))':
+    dependencies:
+      eslint: 10.4.1(jiti@1.21.6)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.10.0': {}
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -10312,6 +10652,13 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.0': {}
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
 
   '@floating-ui/core@1.6.0':
     dependencies:
@@ -10368,6 +10715,18 @@ snapshots:
       - encoding
       - supports-color
 
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -10379,6 +10738,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@hutson/parse-repository-url@3.0.2': {}
 
@@ -10502,10 +10863,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@lerna/create@8.1.2(encoding@0.1.13)(typescript@5.6.3)':
+  '@lerna/create@8.1.2(@swc/core@1.15.40)(encoding@0.1.13)(typescript@5.6.3)':
     dependencies:
       '@npmcli/run-script': 7.0.2
-      '@nx/devkit': 18.2.4(nx@18.2.4)
+      '@nx/devkit': 18.2.4(nx@18.2.4(@swc/core@1.15.40))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       byte-size: 8.1.1
@@ -10542,7 +10903,7 @@ snapshots:
       npm-packlist: 5.1.1
       npm-registry-fetch: 14.0.5
       npmlog: 6.0.2
-      nx: 18.2.4
+      nx: 18.2.4(@swc/core@1.15.40)
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-queue: 6.6.2
@@ -11016,28 +11377,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nrwl/devkit@18.2.4(nx@18.2.4)':
+  '@nrwl/devkit@18.2.4(nx@18.2.4(@swc/core@1.15.40))':
     dependencies:
-      '@nx/devkit': 18.2.4(nx@18.2.4)
+      '@nx/devkit': 18.2.4(nx@18.2.4(@swc/core@1.15.40))
     transitivePeerDependencies:
       - nx
 
-  '@nrwl/tao@18.2.4':
+  '@nrwl/tao@18.2.4(@swc/core@1.15.40)':
     dependencies:
-      nx: 18.2.4
+      nx: 18.2.4(@swc/core@1.15.40)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
       - debug
 
-  '@nx/devkit@18.2.4(nx@18.2.4)':
+  '@nx/devkit@18.2.4(nx@18.2.4(@swc/core@1.15.40))':
     dependencies:
-      '@nrwl/devkit': 18.2.4(nx@18.2.4)
+      '@nrwl/devkit': 18.2.4(nx@18.2.4(@swc/core@1.15.40))
       ejs: 3.1.9
       enquirer: 2.3.6
       ignore: 5.3.1
-      nx: 18.2.4
+      nx: 18.2.4(@swc/core@1.15.40)
       semver: 7.6.3
       tmp: 0.2.3
       tslib: 2.8.1
@@ -11549,6 +11910,61 @@ snapshots:
       hast-util-to-string: 2.0.0
       unist-util-visit: 4.1.2
 
+  '@swc/core-darwin-arm64@1.15.40':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.40':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.40':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.40':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.40':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.40':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.40':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.40':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.40':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.40':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.40':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.40':
+    optional: true
+
+  '@swc/core@1.15.40':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.40
+      '@swc/core-darwin-x64': 1.15.40
+      '@swc/core-linux-arm-gnueabihf': 1.15.40
+      '@swc/core-linux-arm64-gnu': 1.15.40
+      '@swc/core-linux-arm64-musl': 1.15.40
+      '@swc/core-linux-ppc64-gnu': 1.15.40
+      '@swc/core-linux-s390x-gnu': 1.15.40
+      '@swc/core-linux-x64-gnu': 1.15.40
+      '@swc/core-linux-x64-musl': 1.15.40
+      '@swc/core-win32-arm64-msvc': 1.15.40
+      '@swc/core-win32-ia32-msvc': 1.15.40
+      '@swc/core-win32-x64-msvc': 1.15.40
+    optional: true
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.13':
@@ -11558,6 +11974,11 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
+    optional: true
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:
@@ -11597,12 +12018,12 @@ snapshots:
   '@tufjs/models@1.0.4':
     dependencies:
       '@tufjs/canonical-json': 1.0.0
-      minimatch: 9.0.4
+      minimatch: 9.0.9
 
   '@tufjs/models@2.0.0':
     dependencies:
       '@tufjs/canonical-json': 2.0.0
-      minimatch: 9.0.4
+      minimatch: 9.0.9
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -11674,11 +12095,15 @@ snapshots:
       '@types/estree': 1.0.6
       '@types/json-schema': 7.0.15
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.6
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@4.19.0':
     dependencies:
@@ -11759,6 +12184,11 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+    optional: true
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -11831,6 +12261,26 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/type-utils': 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      '@typescript-eslint/utils': 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 7.6.0
+      debug: 4.3.7(supports-color@8.1.1)
+      eslint: 10.4.1(jiti@1.21.6)
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@7.6.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
@@ -11851,13 +12301,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.0)(typescript@5.6.3)':
+  '@typescript-eslint/experimental-utils@5.62.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
-      eslint: 8.57.0
+      '@typescript-eslint/utils': 5.62.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@1.21.6)
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 7.6.0
+      debug: 4.3.7(supports-color@8.1.1)
+      eslint: 10.4.1(jiti@1.21.6)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3)':
     dependencies:
@@ -11882,6 +12345,18 @@ snapshots:
       '@typescript-eslint/types': 7.6.0
       '@typescript-eslint/visitor-keys': 7.6.0
 
+  '@typescript-eslint/type-utils@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      debug: 4.3.7(supports-color@8.1.1)
+      eslint: 10.4.1(jiti@1.21.6)
+      ts-api-utils: 1.3.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/type-utils@7.6.0(eslint@8.57.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.6.3)
@@ -11898,7 +12373,7 @@ snapshots:
 
   '@typescript-eslint/types@7.6.0': {}
 
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -11906,9 +12381,9 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
-      tsutils: 3.21.0(typescript@5.6.3)
+      tsutils: 3.21.0(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11927,16 +12402,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@7.6.0(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/visitor-keys': 7.6.0
+      debug: 4.3.7(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@5.62.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@10.4.1(jiti@1.21.6))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
-      eslint: 8.57.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@6.0.3)
+      eslint: 10.4.1(jiti@1.21.6)
       eslint-scope: 5.1.1
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@10.4.1(jiti@1.21.6))
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.6.0
+      '@typescript-eslint/types': 7.6.0
+      '@typescript-eslint/typescript-estree': 7.6.0(typescript@6.0.3)
+      eslint: 10.4.1(jiti@1.21.6)
       semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
@@ -11968,14 +12472,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react@4.3.3(vite@5.4.10(@types/node@20.17.10)(terser@5.30.3))':
+  '@vitejs/plugin-react@4.3.3(vite@5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.10(@types/node@20.17.10)(terser@5.30.3)
+      vite: 5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12070,7 +12574,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wyw-in-js/transform@1.1.0(typescript@5.6.3)':
+  '@wyw-in-js/transform@1.1.0(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.3
@@ -12081,7 +12585,7 @@ snapshots:
       '@babel/types': 7.26.5
       '@wyw-in-js/processor-utils': 1.1.0
       '@wyw-in-js/shared': 1.1.0
-      cosmiconfig: 8.3.6(typescript@5.6.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       happy-dom: 20.9.0
       minimatch: 9.0.9
       source-map: 0.7.4
@@ -12135,7 +12639,13 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.14.0: {}
+
+  acorn@8.16.0: {}
 
   add-stream@1.0.0: {}
 
@@ -12170,6 +12680,13 @@ snapshots:
       ajv: 6.12.6
 
   ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -12447,6 +12964,8 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   before-after-hook@2.2.3: {}
@@ -12503,6 +13022,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.2:
     dependencies:
@@ -12983,6 +13506,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
+  cosmiconfig@8.3.6(typescript@6.0.3):
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 6.0.3
+
   cosmiconfig@9.0.0(typescript@5.6.3):
     dependencies:
       env-paths: 2.2.1
@@ -13019,6 +13551,12 @@ snapshots:
       cross-spawn: 7.0.3
 
   cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -13146,6 +13684,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
@@ -13218,6 +13760,9 @@ snapshots:
   detect-indent@5.0.0: {}
 
   detect-libc@2.0.3: {}
+
+  detect-libc@2.1.2:
+    optional: true
 
   devlop@1.1.0:
     dependencies:
@@ -13603,21 +14148,21 @@ snapshots:
       object.assign: 4.1.5
       object.entries: 1.1.8
 
-  eslint-config-next@15.0.2(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0)(typescript@5.6.3):
+  eslint-config-next@15.0.2(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 15.0.2
       '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint@8.57.0)(typescript@5.6.3)
-      '@typescript-eslint/parser': 7.6.0(eslint@8.57.0)(typescript@5.6.3)
-      eslint: 8.57.0
+      '@typescript-eslint/eslint-plugin': 7.6.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@8.57.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
-      eslint-plugin-react: 7.37.2(eslint@8.57.0)
-      eslint-plugin-react-hooks: 5.0.0(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@10.4.1(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.1(jiti@1.21.6))
+      eslint-plugin-react: 7.37.2(eslint@10.4.1(jiti@1.21.6))
+      eslint-plugin-react-hooks: 5.0.0(eslint@10.4.1(jiti@1.21.6))
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
@@ -13635,26 +14180,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@10.4.1(jiti@1.21.6)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7(supports-color@8.1.1)
       enhanced-resolve: 5.16.0
-      eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0)
+      eslint: 10.4.1(jiti@1.21.6)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@10.4.1(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)):
+  eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)):
     dependencies:
       array.prototype.find: 2.2.3
       debug: 3.2.7
@@ -13668,19 +14213,30 @@ snapshots:
       lodash: 4.17.21
       resolve: 2.0.0-next.5
       semver: 5.7.2
-      webpack: 5.91.0(esbuild@0.24.0)
+      webpack: 5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@10.4.1(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@10.4.1(jiti@1.21.6))
+      eslint-import-resolver-webpack: 0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.6.0(eslint@8.57.0)(typescript@5.6.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@8.57.0)
-      eslint-import-resolver-webpack: 0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0))
+      eslint-import-resolver-webpack: 0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13697,7 +14253,36 @@ snapshots:
       lodash.snakecase: 4.1.1
       lodash.upperfirst: 4.3.1
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 10.4.1(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@10.4.1(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@10.4.1(jiti@1.21.6))
+      hasown: 2.0.2
+      is-core-module: 2.15.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.8
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.6.0(eslint@10.4.1(jiti@1.21.6))(typescript@6.0.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.8)(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -13708,7 +14293,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -13726,34 +14311,24 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.8)(eslint@8.57.0):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@10.4.1(jiti@1.21.6)):
     dependencies:
-      '@rtsao/scc': 1.1.0
+      aria-query: 5.3.2
       array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.6.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint-plugin-import@2.31.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.8(eslint-plugin-import@2.31.0)(webpack@5.91.0(esbuild@0.24.0)))(eslint@8.57.0)
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.2
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 10.4.1(jiti@1.21.6)
       hasown: 2.0.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
       minimatch: 3.1.2
       object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.8
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.6.0(eslint@8.57.0)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
+      safe-regex-test: 1.0.3
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0):
     dependencies:
@@ -13785,9 +14360,31 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-plugin-react-hooks@5.0.0(eslint@8.57.0):
+  eslint-plugin-react-hooks@5.0.0(eslint@10.4.1(jiti@1.21.6)):
     dependencies:
-      eslint: 8.57.0
+      eslint: 10.4.1(jiti@1.21.6)
+
+  eslint-plugin-react@7.37.2(eslint@10.4.1(jiti@1.21.6)):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.2
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.1.0
+      eslint: 10.4.1(jiti@1.21.6)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.8
+      object.fromentries: 2.0.8
+      object.values: 1.2.0
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.11
+      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.2(eslint@8.57.0):
     dependencies:
@@ -13823,6 +14420,13 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-utils@3.0.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
@@ -13831,6 +14435,45 @@ snapshots:
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.4.1(jiti@1.21.6):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@1.21.6))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+    optionalDependencies:
+      jiti: 1.21.6
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@8.57.0:
     dependencies:
@@ -13875,6 +14518,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
   espree@9.6.1:
     dependencies:
       acorn: 8.14.0
@@ -13888,6 +14537,10 @@ snapshots:
   esprima@4.0.1: {}
 
   esquery@1.5.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -14392,7 +15045,7 @@ snapshots:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
-      minimatch: 9.0.4
+      minimatch: 9.0.9
       minipass: 7.1.2
       path-scurry: 1.10.2
 
@@ -14819,7 +15472,7 @@ snapshots:
 
   ignore-walk@6.0.4:
     dependencies:
-      minimatch: 9.0.4
+      minimatch: 9.0.9
 
   ignore@5.3.1: {}
 
@@ -15230,7 +15883,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
-      ws: 8.16.0
+      ws: 8.20.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -15339,11 +15992,11 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.22
 
-  lerna@8.1.2(encoding@0.1.13):
+  lerna@8.1.2(@swc/core@1.15.40)(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.2(encoding@0.1.13)(typescript@5.6.3)
+      '@lerna/create': 8.1.2(@swc/core@1.15.40)(encoding@0.1.13)(typescript@5.6.3)
       '@npmcli/run-script': 7.0.2
-      '@nx/devkit': 18.2.4(nx@18.2.4)
+      '@nx/devkit': 18.2.4(nx@18.2.4(@swc/core@1.15.40))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       byte-size: 8.1.1
@@ -15386,7 +16039,7 @@ snapshots:
       npm-packlist: 5.1.1
       npm-registry-fetch: 14.0.5
       npmlog: 6.0.2
-      nx: 18.2.4
+      nx: 18.2.4(@swc/core@1.15.40)
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-pipe: 3.1.0
@@ -15449,6 +16102,56 @@ snapshots:
       ssri: 10.0.5
     transitivePeerDependencies:
       - supports-color
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+    optional: true
 
   lilconfig@2.1.0: {}
 
@@ -16234,7 +16937,11 @@ snapshots:
 
   minimatch@10.0.1:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.1.0
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@3.0.5:
     dependencies:
@@ -16644,9 +17351,9 @@ snapshots:
 
   nwsapi@2.2.7: {}
 
-  nx@18.2.4:
+  nx@18.2.4(@swc/core@1.15.40):
     dependencies:
-      '@nrwl/tao': 18.2.4
+      '@nrwl/tao': 18.2.4(@swc/core@1.15.40)
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
@@ -16691,6 +17398,7 @@ snapshots:
       '@nx/nx-linux-x64-musl': 18.2.4
       '@nx/nx-win32-arm64-msvc': 18.2.4
       '@nx/nx-win32-x64-msvc': 18.2.4
+      '@swc/core': 1.15.40
     transitivePeerDependencies:
       - debug
 
@@ -18425,15 +19133,16 @@ snapshots:
 
   temp-dir@1.0.0: {}
 
-  terser-webpack-plugin@5.3.10(esbuild@0.24.0)(webpack@5.91.0(esbuild@0.24.0)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.15.40)(esbuild@0.24.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.30.3
-      webpack: 5.91.0(esbuild@0.24.0)
+      webpack: 5.91.0(@swc/core@1.15.40)(esbuild@0.24.0)
     optionalDependencies:
+      '@swc/core': 1.15.40
       esbuild: 0.24.0
 
   terser@5.30.3:
@@ -18524,6 +19233,10 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
+  ts-api-utils@1.3.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   ts-interface-checker@0.1.13: {}
 
   ts-invariant@0.10.3:
@@ -18549,7 +19262,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.3.5(jiti@1.21.6)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0):
+  tsup@8.3.5(@swc/core@1.15.40)(jiti@1.21.6)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.24.0)
       cac: 6.7.14
@@ -18568,6 +19281,7 @@ snapshots:
       tinyglobby: 0.2.10
       tree-kill: 1.2.2
     optionalDependencies:
+      '@swc/core': 1.15.40
       postcss: 8.4.49
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -18576,10 +19290,10 @@ snapshots:
       - tsx
       - yaml
 
-  tsutils@3.21.0(typescript@5.6.3):
+  tsutils@3.21.0(typescript@6.0.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.6.3
+      typescript: 6.0.3
 
   tsx@4.19.2:
     dependencies:
@@ -18677,6 +19391,8 @@ snapshots:
 
   typescript@5.6.3: {}
 
+  typescript@6.0.3: {}
+
   uc.micro@2.1.0: {}
 
   ufo@1.5.3: {}
@@ -18694,6 +19410,9 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
+
+  undici-types@7.24.6:
+    optional: true
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
@@ -18909,7 +19628,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-plugin-pages@0.32.3(react-router@6.27.0(react@18.3.1))(vite@5.4.10(@types/node@20.17.10)(terser@5.30.3)):
+  vite-plugin-pages@0.32.3(react-router@6.27.0(react@18.3.1))(vite@5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3)):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.3.7(supports-color@8.1.1)
@@ -18919,32 +19638,34 @@ snapshots:
       json5: 2.2.3
       local-pkg: 0.5.0
       picocolors: 1.1.1
-      vite: 5.4.10(@types/node@20.17.10)(terser@5.30.3)
+      vite: 5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3)
       yaml: 2.6.0
     optionalDependencies:
       react-router: 6.27.0(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.4.10(@types/node@20.17.10)(terser@5.30.3):
+  vite@5.4.10(@types/node@25.9.1)(lightningcss@1.32.0)(terser@5.30.3):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.24.3
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 25.9.1
       fsevents: 2.3.3
+      lightningcss: 1.32.0
       terser: 5.30.3
 
-  vite@6.0.5(@types/node@20.17.10)(jiti@1.21.6)(terser@5.30.3)(tsx@4.19.2)(yaml@2.6.0):
+  vite@6.0.5(@types/node@25.9.1)(jiti@1.21.6)(lightningcss@1.32.0)(terser@5.30.3)(tsx@4.19.2)(yaml@2.6.0):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
       rollup: 4.24.3
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 1.21.6
+      lightningcss: 1.32.0
       terser: 5.30.3
       tsx: 4.19.2
       yaml: 2.6.0
@@ -18974,7 +19695,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.91.0(esbuild@0.24.0):
+  webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -18997,7 +19718,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.24.0)(webpack@5.91.0(esbuild@0.24.0))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.15.40)(esbuild@0.24.0)(webpack@5.91.0(@swc/core@1.15.40)(esbuild@0.24.0))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/pigment-css/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

## Overview
Closes #6
Implemented `turbopack-loader.ts` and integrated it into `pigment-css-nextjs-plugin/src/index.ts` with hybrid Webpack/Turbopack support.

## Changes
- Removed the branching within `withPigment` in `packages/pigment-css-nextjs-plugin/src/index.ts`.
- Modified to simultaneously set up `nextConfig.webpack` for Webpack and `nextConfig.turbopack` for Turbopack, always returning an object containing both settings.

## Test and Verification
Confirmed that startup, build, and style application work correctly in the following environments.

`examples/pigment-css-nextjs-ts`:
- [x] `pnpm dev` (Turbopack default startup) -> Starts successfully, style applied (confirmed)
- [x] `pnpm dev --webpack` (Webpack forced startup) -> Starts successfully, style applied (confirmed)
- [x] `pnpm build` -> Build succeeds without errors


## How to verify locally
1. Temporarily update `pnpm-workspace.yaml` to include `"examples/*"`:

2. In `examples/pigment-css-nextjs-ts/package.json`, change `@pigment-css/nextjs-plugin` from `"latest"` to `"workspace:^"`:

3. Run `pnpm dev`, `pnpm build`, `pnpm start` in both Turbopack and Webpack mode.

Styles may not be installed due to the cache in the `.next` file. If your `.next` file is old, please delete it before starting the application.